### PR TITLE
feat: lote de fixes e features (30/08) — toast dark mode, YouTube rate limit, changelog in-app, etc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,3 +216,9 @@ Vocabulário padrão dos 5 papéis canônicos, mapeado pra propriedade `Triagem`
 ### Domain docs
 
 Layout de contexto único (`CONTEXT.md` + `docs/adr/` na raiz). Ver `docs/agents/domain.md`.
+
+### Grilling / perguntas de esclarecimento
+
+Ao rodar uma sessão de grilling (skill `grilling`) ou qualquer rodada de perguntas de
+esclarecimento ao usuário, sempre usar a ferramenta `AskUserQuestion` (uma pergunta por vez, com
+opções e recomendação marcada) em vez de listar as perguntas em texto corrido.

--- a/app/(app)/(drawer)/ministerios/templates_equipe/add.tsx
+++ b/app/(app)/(drawer)/ministerios/templates_equipe/add.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { router, useLocalSearchParams } from 'expo-router';
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -11,10 +11,33 @@ import { AxiosError } from 'axios';
 import TemplateForm from '../../../../../components/pages/ministerios/templates_equipe/TemplateForm';
 import { strfyObj } from '../../../../../utils/text_utils';
 import { EscalaTemplateTipoEnum } from '../../../../../domain/enums/EscalaTemplate/escala-template-tipo.enum';
+import { MinisterioTipoEnum } from '../../../../../domain/enums/Ministerio/ministerio-tipo.enum';
 import { useLoading } from '../../../../../contexts/LoadingContext';
+import { useMinisteriosCrud } from '../../../../../hooks/useMinisteriosCrud';
+import { DynamicQuery, Operator, ValueType } from '../../../../../domain/utils/query_utils';
 
 export default function MinisterioTemplatesAddPage() {
   const { ministerioId } = useLocalSearchParams<{ ministerioId: string }>();
+
+  const ministerioSearchParams = useMemo<DynamicQuery>(
+    () => ({
+      where: {
+        conditions: [
+          {
+            path: 'id',
+            operator: Operator.EQUALS,
+            value: { type: ValueType.LITERAL, value: ministerioId },
+          },
+        ],
+      },
+    }),
+    [ministerioId],
+  );
+
+  const { data: ministeriosData } = useMinisteriosCrud({
+    initialParams: ministerioSearchParams,
+  });
+  const ministerio = ministeriosData[0];
 
   const form = useForm<EscalaTemplateFormData>({
     resolver: zodResolver(escalaTemplateSchema),
@@ -32,6 +55,29 @@ export default function MinisterioTemplatesAddPage() {
   const handleOnSave = useCallback(
     form.handleSubmit(
       async (data) => {
+        if (ministerio?.tipo === MinisterioTipoEnum.Louvor) {
+          if (
+            data.tipo === EscalaTemplateTipoEnum.Fixo &&
+            !data.respSetListVoluntariosId
+          ) {
+            form.setError('respSetListVoluntariosId', {
+              type: 'custom',
+              message: 'Informe o responsável pelo setlist para ministérios de louvor.',
+            });
+            return;
+          }
+          if (
+            data.tipo === EscalaTemplateTipoEnum.Funcoes &&
+            !data.respSetListFuncoesId
+          ) {
+            form.setError('respSetListFuncoesId', {
+              type: 'custom',
+              message: 'Informe o responsável pelo setlist para ministérios de louvor.',
+            });
+            return;
+          }
+        }
+
         showLoading('Salvando...');
         try {
           const { respSetListVoluntariosId, respSetListFuncoesId, ...rest } = data;
@@ -70,6 +116,7 @@ export default function MinisterioTemplatesAddPage() {
       <TemplateForm
         mode='add'
         ministerioId={ministerioId}
+        ministerioTipo={ministerio?.tipo}
         onSave={handleOnSave}
         isLoading={isLoadingMutation}
       />

--- a/app/(app)/(drawer)/ministerios/templates_equipe/edit.tsx
+++ b/app/(app)/(drawer)/ministerios/templates_equipe/edit.tsx
@@ -11,14 +11,39 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { DynamicQuery, Operator, ValueType } from '../../../../../domain/utils/query_utils';
 import FancyLoading from '../../../../../components/FancyLoading';
 import { strfyObj } from '../../../../../utils/text_utils';
-import { EscalaTemplateTipoEnumMap } from '../../../../../domain/enums/EscalaTemplate/escala-template-tipo.enum';
+import {
+  EscalaTemplateTipoEnum,
+  EscalaTemplateTipoEnumMap,
+} from '../../../../../domain/enums/EscalaTemplate/escala-template-tipo.enum';
+import { MinisterioTipoEnum } from '../../../../../domain/enums/Ministerio/ministerio-tipo.enum';
 import { useLoading } from '../../../../../contexts/LoadingContext';
+import { useMinisteriosCrud } from '../../../../../hooks/useMinisteriosCrud';
 
 export default function MinisterioTemplatesEditPage() {
   const { ministerioId, templateId } = useLocalSearchParams<{
     ministerioId: string;
     templateId: string;
   }>();
+
+  const ministerioSearchParams = useMemo<DynamicQuery>(
+    () => ({
+      where: {
+        conditions: [
+          {
+            path: 'id',
+            operator: Operator.EQUALS,
+            value: { type: ValueType.LITERAL, value: ministerioId },
+          },
+        ],
+      },
+    }),
+    [ministerioId],
+  );
+
+  const { data: ministeriosData } = useMinisteriosCrud({
+    initialParams: ministerioSearchParams,
+  });
+  const ministerio = ministeriosData[0];
 
   const dataParams = useMemo(() => {
     if (!templateId) return undefined;
@@ -93,6 +118,29 @@ export default function MinisterioTemplatesEditPage() {
       async (data) => {
         if (!data.id) return;
 
+        if (ministerio?.tipo === MinisterioTipoEnum.Louvor) {
+          if (
+            data.tipo === EscalaTemplateTipoEnum.Fixo &&
+            !data.respSetListVoluntariosId
+          ) {
+            form.setError('respSetListVoluntariosId', {
+              type: 'custom',
+              message: 'Informe o responsável pelo setlist para ministérios de louvor.',
+            });
+            return;
+          }
+          if (
+            data.tipo === EscalaTemplateTipoEnum.Funcoes &&
+            !data.respSetListFuncoesId
+          ) {
+            form.setError('respSetListFuncoesId', {
+              type: 'custom',
+              message: 'Informe o responsável pelo setlist para ministérios de louvor.',
+            });
+            return;
+          }
+        }
+
         showLoading('Salvando...');
         try {
           const { respSetListVoluntariosId, respSetListFuncoesId, ...rest } = data;
@@ -128,6 +176,7 @@ export default function MinisterioTemplatesEditPage() {
       <TemplateForm
         mode='edit'
         ministerioId={ministerioId}
+        ministerioTipo={ministerio?.tipo}
         onSave={handleOnSave}
         isLoading={isLoadingMutation}
       />

--- a/app/(app)/(drawer)/ministerios/templates_equipe/index.tsx
+++ b/app/(app)/(drawer)/ministerios/templates_equipe/index.tsx
@@ -185,7 +185,11 @@ export default function MinisterioTemplateEquipeIndex() {
       searchBarProps={{ value: searchText, onSearch: handleSearch }}
       topContent={
         <View style={styles.topContainer}>
-          {tour.showBanner && <TutorialBanner onStart={tour.start} onDismiss={tour.skip} />}
+          {tour.showBanner && (
+            <View style={styles.bannerWrapper}>
+              <TutorialBanner onStart={tour.start} onDismiss={tour.skip} />
+            </View>
+          )}
           <FancyListStats
             items={[
               { label: 'Total', value: stats.total },
@@ -273,6 +277,9 @@ export default function MinisterioTemplateEquipeIndex() {
 
 const styles = StyleSheet.create({
   topContainer: { gap: 12 },
+  bannerWrapper: {
+    paddingHorizontal: 15,
+  },
   filtroContainer: {
     paddingHorizontal: 15,
   },

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -23,6 +23,7 @@ import { refreshFontScale } from '../constants/font';
 import { registerForPushNotificationsAsync } from '../services/notifications';
 import { NotificationsManager } from '../components/Notification_manager';
 import { AppReviewManager } from '../components/AppReviewManager';
+import { ChangelogManager } from '../components/ChangelogManager';
 import * as Sentry from '@sentry/react-native';
 import * as Updates from 'expo-updates';
 import { ConnectivityProvider } from '../core/network/connectivity/ConnectivityProvider';
@@ -340,6 +341,7 @@ function RootLayoutNav({
       <View style={styles.rootContainer}>
         <NotificationsManager />
         {user && <AppReviewManager />}
+        {user && <ChangelogManager />}
         <StatusBar backgroundColor='transparent' style={statusBarStyle} translucent />
         <SafeAreaView
           style={[styles.navigationContainer, { backgroundColor: safeAreaBackgroundColor }]}

--- a/components/ChangelogManager.tsx
+++ b/components/ChangelogManager.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { resolvePendingChangelog, PendingChangelog } from '../hooks/useChangelog';
+import ChangelogSheet from './ChangelogSheet';
+
+export function ChangelogManager() {
+  const [pending, setPending] = useState<PendingChangelog | null>(null);
+
+  useEffect(() => {
+    const timeout = setTimeout(async () => {
+      const result = await resolvePendingChangelog();
+      if (result) setPending(result);
+    }, 3000);
+
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (!pending) return null;
+
+  return (
+    <ChangelogSheet
+      visible
+      version={pending.currentVersion}
+      items={pending.entries.flatMap((entry) => entry.items)}
+      onClose={() => setPending(null)}
+    />
+  );
+}

--- a/components/ChangelogSheet.tsx
+++ b/components/ChangelogSheet.tsx
@@ -1,0 +1,79 @@
+import { StyleSheet, View } from 'react-native';
+import FancyBottomSheetModal from './modal/FancyBottomSheetModal';
+import FancyButton from './buttons/FancyButton';
+import FancyText from './FancyText';
+import DefaultIcons from './FancyIcons';
+import { usePallete } from '../hooks/usePallete';
+import { ColorUtils } from '../utils/color_utils';
+import { ChangelogItem } from '../constants/changelog';
+
+type Props = {
+  visible: boolean;
+  version: string;
+  items: ChangelogItem[];
+  onClose: () => void;
+};
+
+export default function ChangelogSheet({ visible, version, items, onClose }: Props) {
+  const palette = usePallete();
+
+  return (
+    <FancyBottomSheetModal
+      visible={visible}
+      onClose={onClose}
+      title={`Novidades da versão ${version}`}
+      footer={<FancyButton label='Entendi' onPress={onClose} />}
+    >
+      <View style={styles.list}>
+        {items.map((item, index) => {
+          const accentColor = palette[item.accent ?? 'primary'];
+          return (
+            <View key={index} style={styles.row}>
+              <View
+                style={[styles.iconWrap, { backgroundColor: ColorUtils.withAlpha(accentColor, 0.14) }]}
+              >
+                <DefaultIcons.Custom
+                  library={item.icon.library}
+                  name={item.icon.name}
+                  size={22}
+                  color={accentColor}
+                />
+              </View>
+              <View style={styles.textColumn}>
+                <FancyText type='bold' size='small' color={palette.fonts.dark}>
+                  {item.title}
+                </FancyText>
+                <FancyText type='medium' size='small' color={palette.fonts.inactive}>
+                  {item.description}
+                </FancyText>
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    </FancyBottomSheetModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    gap: 20,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 14,
+  },
+  iconWrap: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  textColumn: {
+    flex: 1,
+    gap: 3,
+    justifyContent: 'center',
+  },
+});

--- a/components/forms/ControlledSearchSelect.tsx
+++ b/components/forms/ControlledSearchSelect.tsx
@@ -22,6 +22,7 @@ interface ControlledSearchSelectProps<
   | 'retryLabel'
   | 'labelProps'
   | 'onClosed'
+  | 'multiSelect'
 > {
   control: Control<TFormValues>;
   name: TName;

--- a/components/images/FancyImage.tsx
+++ b/components/images/FancyImage.tsx
@@ -51,7 +51,7 @@ export default function FancyImage({
     >
       <Image
         contentFit='cover'
-        transition={100}
+        transition={isEmptyProfilePlaceholder ? 0 : 100}
         priority='low'
         cachePolicy='memory-disk'
         source={isEmptyProfilePlaceholder ? undefined : resolvedSource}

--- a/components/pages/admin/solicitacoes/NovoConviteModal.tsx
+++ b/components/pages/admin/solicitacoes/NovoConviteModal.tsx
@@ -1,10 +1,11 @@
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import FancyText from '../../../FancyText';
 import FancyTextInput from '../../../fields/FancyTextInput';
 import FancyChips from '../../../FancyChips';
 import FancyBottomSheetModal from '../../../modal/FancyBottomSheetModal';
 import FancyButton from '../../../buttons/FancyButton';
+import FancySearchSelect from '../../../fields/FancySearchSelect';
 import DefaultIcons from '../../../FancyIcons';
 import { ThemePalette } from '../../../../constants/colors';
 import { CreateIgrejaConviteDto } from '../../../../domain/dtos/Igreja/create-igreja-convite.dto';
@@ -12,6 +13,8 @@ import { addDays } from 'date-fns';
 import { usePallete } from '../../../../hooks/usePallete';
 import { useThemedStyles } from '../../../../hooks/useThemedStyles';
 import { ColorUtils } from '../../../../utils/color_utils';
+import { useMinisteriosCrud } from '../../../../hooks/useMinisteriosCrud';
+import { DropDownItemProps } from '../../../fields/FancyDropDownItem';
 
 type NovoConviteModalProps = {
   visible: boolean;
@@ -47,6 +50,13 @@ export default function NovoConviteModal({
   const [autoApprove, setAutoApprove] = useState(false);
   const [maxUses, setMaxUses] = useState<number | null>(1);
   const [validadeDias, setValidadeDias] = useState<number | null>(7);
+  const [ministerioIds, setMinisterioIds] = useState<string[]>([]);
+
+  const { data: ministeriosData } = useMinisteriosCrud({ autoFetch: true });
+  const ministeriosDropDownList = useMemo<DropDownItemProps<string>[]>(
+    () => (ministeriosData ?? []).map((m) => ({ title: m.nome, value: m.id })),
+    [ministeriosData],
+  );
 
   const handleCriar = () => {
     const dto: CreateIgrejaConviteDto = {
@@ -54,6 +64,7 @@ export default function NovoConviteModal({
       autoApprove,
       maxUses: maxUses ?? undefined,
       expiresAt: validadeDias ? addDays(new Date(), validadeDias).toISOString() : undefined,
+      ministerioIds: ministerioIds.length > 0 ? ministerioIds : undefined,
     };
     onCriar(dto);
   };
@@ -64,6 +75,7 @@ export default function NovoConviteModal({
     setAutoApprove(false);
     setMaxUses(1);
     setValidadeDias(7);
+    setMinisterioIds([]);
     onClose();
   };
 
@@ -110,6 +122,27 @@ export default function NovoConviteModal({
             onChangeText: setDescricao,
             maxLength: 100,
           }}
+        />
+      </View>
+
+      {/* Ministérios (opcional) */}
+      <View style={styles.section}>
+        <FancyText
+          size='small'
+          type='semiBold'
+          color={palette.fonts.inactive}
+          style={styles.sectionLabel}
+        >
+          Ministérios (opcional)
+        </FancyText>
+        <FancySearchSelect
+          multiSelect
+          placeholder='Nenhum — só entra na igreja'
+          searchPlaceholder='Buscar ministério...'
+          listItems={ministeriosDropDownList}
+          value={ministerioIds}
+          onChange={(value) => setMinisterioIds(Array.isArray(value) ? value : [])}
+          disabled={isLoading}
         />
       </View>
 

--- a/components/pages/common/EventoSetlistTab.tsx
+++ b/components/pages/common/EventoSetlistTab.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Alert, Pressable, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 import { router } from 'expo-router';
 import DraggableFlatList, { RenderItemParams } from 'react-native-draggable-flatlist';
 import Toast from 'react-native-toast-message';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 import FancyBottomSheetModal from '../../modal/FancyBottomSheetModal';
+import { FancyAlert } from '../../modal/FancyAlert';
 import FancySeparator from '../../FancySeparator';
 import FancyButton from '../../buttons/FancyButton';
 import FancyBottomSheetSelect from '../../fields/FancyBottomSheetSelect';
@@ -314,7 +315,7 @@ export default function EventoSetlistTab({
   };
 
   const confirmDeleteItem = (item: ResponseEventoSetlistItemDto) => {
-    Alert.alert('Excluir música?', 'Essa ação não pode ser desfeita.', [
+    FancyAlert.alert('Excluir música?', 'Essa ação não pode ser desfeita.', [
       { text: 'Cancelar', style: 'cancel' },
       {
         text: 'Excluir',
@@ -609,40 +610,26 @@ export default function EventoSetlistTab({
         ministerioId={ministerioId}
         onClose={() => setEditorVisible(false)}
         onSave={async (payload) => {
+          const dto = {
+            ministerioId: ministerioId || '',
+            dataOcorrencia: dataOcorrenciaIso,
+            tipoOrigem: payload.tipoOrigem,
+            repertorioMusicaId: payload.repertorioMusicaId,
+            nome: payload.nome,
+            interprete: payload.interprete,
+            versaoUrl: payload.versaoUrl,
+            tom: payload.tom,
+            bpm: payload.bpm,
+            letraMarkdown: payload.letraMarkdown,
+            cifraMarkdown: payload.cifraMarkdown,
+            observacoes: payload.observacoes,
+          };
+
           try {
             if (payload.itemId) {
-              await atualizarSetlistItem({
-                itemId: payload.itemId,
-                dto: {
-                  ministerioId: ministerioId || '',
-                  dataOcorrencia: dataOcorrenciaIso,
-                  tipoOrigem: payload.tipoOrigem,
-                  repertorioMusicaId: payload.repertorioMusicaId,
-                  nome: payload.nome,
-                  interprete: payload.interprete,
-                  versaoUrl: payload.versaoUrl,
-                  tom: payload.tom,
-                  bpm: payload.bpm,
-                  letraMarkdown: payload.letraMarkdown,
-                  cifraMarkdown: payload.cifraMarkdown,
-                  observacoes: payload.observacoes,
-                },
-              });
+              await atualizarSetlistItem({ itemId: payload.itemId, dto });
             } else {
-              await criarSetlistItem({
-                ministerioId: ministerioId || '',
-                dataOcorrencia: dataOcorrenciaIso,
-                tipoOrigem: payload.tipoOrigem,
-                repertorioMusicaId: payload.repertorioMusicaId,
-                nome: payload.nome,
-                interprete: payload.interprete,
-                versaoUrl: payload.versaoUrl,
-                tom: payload.tom,
-                bpm: payload.bpm,
-                letraMarkdown: payload.letraMarkdown,
-                cifraMarkdown: payload.cifraMarkdown,
-                observacoes: payload.observacoes,
-              });
+              await criarSetlistItem(dto);
             }
           } catch (error) {
             Toast.show({

--- a/components/pages/common/YoutubeVersionSearchSheet.tsx
+++ b/components/pages/common/YoutubeVersionSearchSheet.tsx
@@ -7,6 +7,7 @@ import FancyListEmpty from '../../list/FancyListEmpty';
 import FancyTextInput from '../../fields/FancyTextInput';
 import FancyText from '../../FancyText';
 import DefaultIcons from '../../FancyIcons';
+import { AxiosError } from 'axios';
 import { useYoutubeVersionSearch } from '../../../hooks/useRepertorio';
 import { ResponseYoutubeSearchItemDto } from '../../../domain/dtos/Repertorio/youtube-search-item.response';
 import { usePallete } from '../../../hooks/usePallete';
@@ -43,7 +44,13 @@ export default function YoutubeVersionSearchSheet({
     return () => clearTimeout(timeout);
   }, [searchText, visible]);
 
-  const { data = [], isFetching, isError } = useYoutubeVersionSearch(debouncedQuery, visible, 6);
+  const {
+    data = [],
+    isFetching,
+    isError,
+    error,
+  } = useYoutubeVersionSearch(debouncedQuery, visible, 6);
+  const isRateLimited = (error as AxiosError)?.response?.status === 429;
 
   const searchUrl = useMemo(() => {
     const normalized = searchText.trim();
@@ -79,11 +86,15 @@ export default function YoutubeVersionSearchSheet({
     if (isError) {
       return (
         <FancyListEmpty
-          label='Serviço indisponível'
-          helperText='Não foi possível buscar agora. Tente abrir no YouTube ou continue manualmente.'
+          label={isRateLimited ? 'Muitas buscas agora' : 'Serviço indisponível'}
+          helperText={
+            isRateLimited
+              ? 'Muita gente buscando no YouTube ao mesmo tempo. Tente novamente em alguns minutos, ou continue manualmente.'
+              : 'Não foi possível buscar agora. Tente abrir no YouTube ou continue manualmente.'
+          }
           icon={{
             library: 'MaterialCommunityIcons',
-            name: 'wifi-off',
+            name: isRateLimited ? 'clock-outline' : 'wifi-off',
             size: 48,
             color: palette.warning,
           }}

--- a/components/pages/ministerios/agenda/AgendaDetailsDadosTab.tsx
+++ b/components/pages/ministerios/agenda/AgendaDetailsDadosTab.tsx
@@ -353,6 +353,10 @@ export default function AgendaDetailsDadosTab(props: {
       ) ?? false,
     [igrejaAtiva?.ministerios, props.ministerioId],
   );
+  // Mesmo dado por trás dos dois rótulos — Ministério de Louvor vê "Ensaio", os demais veem
+  // "Chegada" (ver CONTEXT.md "Horário de Ensaio/Chegada").
+  const ensaioChegadaLabel = isLouvorMinisterio ? 'ensaio' : 'chegada';
+  const EnsaioChegadaLabel = isLouvorMinisterio ? 'Ensaio' : 'Chegada';
   const { data: templates, isLoading: isLoadingTemplates } = useEscalaTemplatesCrud({
     autoFetch: false,
     initialParams: {
@@ -594,13 +598,13 @@ export default function AgendaDetailsDadosTab(props: {
       if (!isValid && showToast) {
         FancyAlert.alert(
           'Horário inválido',
-          `O ensaio precisa começar ao menos 30 min antes da ocorrência às ${occurrenceTimeLabel}.`,
+          `O ${ensaioChegadaLabel} precisa começar ao menos 30 min antes da ocorrência às ${occurrenceTimeLabel}.`,
         );
       }
 
       return isValid;
     },
-    [occurrenceTimeLabel, props.dataOcorrenciaDate],
+    [ensaioChegadaLabel, occurrenceTimeLabel, props.dataOcorrenciaDate],
   );
 
   const origemEnsaioLabel = useMemo(() => {
@@ -815,6 +819,7 @@ export default function AgendaDetailsDadosTab(props: {
         const response = await salvarEnsaio({
           eventoId,
           data: {
+            ministerioId: props.ministerioId,
             dataOcorrencia: props.dataOcorrenciaIso,
             escopo,
             horarioEnsaio: formatHourMinuteToTime(ensaioTime),
@@ -829,6 +834,7 @@ export default function AgendaDetailsDadosTab(props: {
           await removerEnsaio({
             eventoId,
             params: {
+              ministerioId: props.ministerioId,
               escopo: TemplatePadraoEscopoEnum.OCORRENCIA,
               dataOcorrencia: props.dataOcorrenciaIso,
             },
@@ -839,16 +845,18 @@ export default function AgendaDetailsDadosTab(props: {
       } catch (error) {
         Toast.show({
           type: 'error',
-          text1: 'Erro ao salvar horário de ensaio',
-          text2: getApiErrorMessage(error, 'Não foi possível salvar o horário de ensaio.'),
+          text1: `Erro ao salvar horário de ${ensaioChegadaLabel}`,
+          text2: getApiErrorMessage(error, `Não foi possível salvar o horário de ${ensaioChegadaLabel}.`),
         });
         return false;
       }
     },
     [
+      ensaioChegadaLabel,
       ensaioTime,
       props.dataOcorrenciaIso,
       props.evento.id,
+      props.ministerioId,
       props.ocorrencia?.eventoId,
       removerEnsaio,
       salvarEnsaio,
@@ -1057,7 +1065,7 @@ export default function AgendaDetailsDadosTab(props: {
       if (templateDirty) propagableLabels.push('template da equipe');
       if (isLouvorMinisterio && responsavelSetlistDirty)
         propagableLabels.push('responsável do setlist');
-      if (ensaioDirty) propagableLabels.push('horário de ensaio');
+      if (ensaioDirty) propagableLabels.push(`horário de ${ensaioChegadaLabel}`);
 
       if (propagableLabels.length > 0) {
         const scope = await promptConsolidatedScope(propagableLabels);
@@ -1122,6 +1130,7 @@ export default function AgendaDetailsDadosTab(props: {
   }, [
     canManageOccurrence,
     dadosDirty,
+    ensaioChegadaLabel,
     ensaioDirty,
     hideLoading,
     isLouvorMinisterio,
@@ -1299,7 +1308,7 @@ export default function AgendaDetailsDadosTab(props: {
                 ) : null}
 
                 <OccurrenceFieldSection
-                  label='Horário de ensaio'
+                  label={`Horário de ${EnsaioChegadaLabel}`}
                   origin={origemEnsaioLabel}
                   dirty={ensaioDirty}
                   editor={
@@ -1376,7 +1385,7 @@ export default function AgendaDetailsDadosTab(props: {
                               setEnsaioTime(time);
                               setIsTimePickerVisible(false);
                             }}
-                            title='Horário de ensaio'
+                            title={`Horário de ${EnsaioChegadaLabel}`}
                           />
                         </>
                       ) : (

--- a/components/pages/ministerios/integrantes/FormFields.tsx
+++ b/components/pages/ministerios/integrantes/FormFields.tsx
@@ -5,7 +5,7 @@ import { DefaultIconsNames } from '../../../../constants/icons';
 import {
   MinVoluntarioFormData,
   MinVoluntarioFuncaoFormData,
-  minVoluntarioFuncaoSchema,
+  minVoluntarioFuncaoModalSchema,
 } from '../../../../domain/schemas/ministerioVoluntariosSchema';
 import { useMemo, useState } from 'react';
 import IntegranteFormModal from './FormModal';
@@ -81,25 +81,28 @@ export default function IntegranteFormFields({
   });
 
   const formModal = useForm({
-    resolver: zodResolver(minVoluntarioFuncaoSchema),
+    resolver: zodResolver(minVoluntarioFuncaoModalSchema),
   });
 
   const handleSave = formModal.handleSubmit((data) => {
     // console.log('Saving funcao data:', strfyObj({ data, funcoesList }));
 
-    const findedFuncao = funcoesList.find((f) => f.id === data.id);
     const current = getValues('funcoes') as MinVoluntarioFuncaoFormData[];
+    const selectedIds = Array.isArray(data.id) ? data.id : [data.id];
 
-    const existingIndex = current.findIndex((f) => f.id === data.id);
+    selectedIds.forEach((funcaoId) => {
+      const findedFuncao = funcoesList.find((f) => f.id === funcaoId);
+      const existingIndex = current.findIndex((f) => f.id === funcaoId);
 
-    const newItem: MinVoluntarioFuncaoFormData = {
-      id: data.id,
-      experiencia: data.experiencia,
-      nome: findedFuncao?.nome || 'Nome não encontrado',
-    };
+      const newItem: MinVoluntarioFuncaoFormData = {
+        id: funcaoId,
+        experiencia: data.experiencia,
+        nome: findedFuncao?.nome || 'Nome não encontrado',
+      };
 
-    if (existingIndex === -1) append(newItem);
-    else update(existingIndex, newItem);
+      if (existingIndex === -1) append(newItem);
+      else update(existingIndex, newItem);
+    });
 
     handleClearForm();
     setFormModalOptions({ visible: false, mode: 'add' });

--- a/components/pages/ministerios/integrantes/FormModal.tsx
+++ b/components/pages/ministerios/integrantes/FormModal.tsx
@@ -2,7 +2,7 @@ import { useFormContext } from 'react-hook-form';
 import { StyleSheet, View } from 'react-native';
 import FancyBottomSheetModal from '../../../modal/FancyBottomSheetModal';
 import FancyButton from '../../../buttons/FancyButton';
-import { MinVoluntarioFuncaoFormData } from '../../../../domain/schemas/ministerioVoluntariosSchema';
+import { MinVoluntarioFuncaoModalFormData } from '../../../../domain/schemas/ministerioVoluntariosSchema';
 import { DropDownItemProps } from '../../../fields/FancyDropDownItem';
 import { useMemo } from 'react';
 import { EnumUtils } from '../../../../utils/enum_utils';
@@ -30,7 +30,7 @@ export default function IntegranteFormModal({
   onButton1Press,
   onButton2Press,
 }: IntegranteFormModalProps) {
-  const { control } = useFormContext<MinVoluntarioFuncaoFormData>();
+  const { control } = useFormContext<MinVoluntarioFuncaoModalFormData>();
 
   const experiencaList = useMemo<DropDownItemProps<EscalaTemplateExperienciaEnum>[]>(() => {
     return EnumUtils.getDropDownItems(
@@ -60,10 +60,11 @@ export default function IntegranteFormModal({
     >
       <ControlledSearchSelect
         name='id'
-        label='Função'
+        label={mode === 'add' ? 'Funções' : 'Função'}
         control={control}
         listItems={funcoesDropDownList}
         disabled={mode === 'edit'}
+        multiSelect={mode === 'add'}
         searchPlaceholder='Buscar função...'
       />
       <ControlledBottomSheetSelect

--- a/components/pages/ministerios/templates_equipe/TemplateForm.tsx
+++ b/components/pages/ministerios/templates_equipe/TemplateForm.tsx
@@ -20,10 +20,12 @@ import {
   EscalaTemplateTipoEnumMap,
 } from '../../../../domain/enums/EscalaTemplate/escala-template-tipo.enum';
 import { MinisterioFuncaoStatusEnum } from '../../../../domain/enums/MinisterioFuncao/ministerio-funcao-status.enum';
+import { MinisterioTipoEnum } from '../../../../domain/enums/Ministerio/ministerio-tipo.enum';
 
 export interface TemplateFormProps {
   mode: 'add' | 'edit';
   ministerioId?: string;
+  ministerioTipo?: MinisterioTipoEnum;
   onSave?: () => void;
   isLoading?: boolean;
 }
@@ -31,6 +33,7 @@ export interface TemplateFormProps {
 export default function TemplateForm({
   mode = 'add',
   ministerioId,
+  ministerioTipo,
   onSave,
   isLoading = false,
 }: TemplateFormProps) {
@@ -119,13 +122,15 @@ export default function TemplateForm({
         <FormProvider {...form}>
           {EscalaTemplateTipoEnumMap[tipoWatch] === EscalaTemplateTipoEnum.Funcoes && (
             <>
-              <ControlledBottomSheetSelect
-                control={form.control}
-                name={'respSetListFuncoesId'}
-                label='Responsável pelo setlist'
-                listItems={respSetListFuncoesDropDownList}
-                disabled={isFormDisabled}
-              />
+              {ministerioTipo === MinisterioTipoEnum.Louvor && (
+                <ControlledBottomSheetSelect
+                  control={form.control}
+                  name={'respSetListFuncoesId'}
+                  label='Responsável pelo setlist'
+                  listItems={respSetListFuncoesDropDownList}
+                  disabled={isFormDisabled}
+                />
+              )}
               <TemplateFuncoesList
                 funcoesList={funcoesDropDownList}
                 disabled={isFormDisabled}
@@ -136,13 +141,15 @@ export default function TemplateForm({
           )}
           {EscalaTemplateTipoEnumMap[tipoWatch] === EscalaTemplateTipoEnum.Fixo && (
             <>
-              <ControlledBottomSheetSelect
-                control={form.control}
-                name={'respSetListVoluntariosId'}
-                label='Responsável pelo setlist'
-                disabled={isFormDisabled}
-                listItems={respSetListVoluntariosDropDownList}
-              />
+              {ministerioTipo === MinisterioTipoEnum.Louvor && (
+                <ControlledBottomSheetSelect
+                  control={form.control}
+                  name={'respSetListVoluntariosId'}
+                  label='Responsável pelo setlist'
+                  disabled={isFormDisabled}
+                  listItems={respSetListVoluntariosDropDownList}
+                />
+              )}
               <TemplateFixoEquipeList
                 disabled={isFormDisabled}
                 voluntariosList={ministerioVoluntariosList}

--- a/components/song/MusicListenButton.tsx
+++ b/components/song/MusicListenButton.tsx
@@ -67,7 +67,7 @@ export default function MusicListenButton({ url, showLabel = false }: Props) {
 const styles = StyleSheet.create({
   iconWrap: {
     width: 30,
-    height: 38,
+    height: 30,
     borderRadius: 12,
     borderWidth: 0.6,
     alignItems: 'center',

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -1,0 +1,19 @@
+import { IconLibrary } from '../components/FancyIcons';
+
+// Conteúdo do changelog in-app, versionado no código (sem CMS por ora).
+// Ao lançar uma versão com novidades pro usuário, adicione uma entrada no topo
+// da lista com o `version` exato de app.json.
+export type ChangelogItem = {
+  icon: { library: IconLibrary; name: string };
+  title: string;
+  description: string;
+  // Cor de destaque do ícone — usa os tokens já existentes no tema. Padrão: 'primary'.
+  accent?: 'primary' | 'secondary' | 'terciary' | 'confirm' | 'warning';
+};
+
+export type ChangelogEntry = {
+  version: string;
+  items: ChangelogItem[];
+};
+
+export const CHANGELOG: ChangelogEntry[] = [];

--- a/domain/dtos/Evento/update-evento-ensaio.dto.ts
+++ b/domain/dtos/Evento/update-evento-ensaio.dto.ts
@@ -1,6 +1,7 @@
 import { TemplatePadraoEscopoEnum } from '../../enums/Evento/template-padrao-escopo.enum';
 
 export type UpdateEventoEnsaioDto = {
+  ministerioId: string;
   dataOcorrencia: string;
   escopo: TemplatePadraoEscopoEnum;
   horarioEnsaio: string;
@@ -8,12 +9,14 @@ export type UpdateEventoEnsaioDto = {
 };
 
 export type RemoveEventoEnsaioDto = {
+  ministerioId: string;
   escopo: TemplatePadraoEscopoEnum;
   dataOcorrencia: string;
 };
 
 export type ResponseEventoEnsaioDto = {
   eventoId: string;
+  ministerioId: string;
   dataOcorrencia: string;
   escopo: TemplatePadraoEscopoEnum;
   horarioEnsaio: string | null;

--- a/domain/dtos/Igreja/create-igreja-convite.dto.ts
+++ b/domain/dtos/Igreja/create-igreja-convite.dto.ts
@@ -6,4 +6,5 @@ export interface CreateIgrejaConviteDto {
   roleSugerida?: IgrejaVoluntarioRoleEnum;
   maxUses?: number;
   expiresAt?: string;
+  ministerioIds?: string[];
 }

--- a/domain/schemas/ministerioVoluntariosSchema.ts
+++ b/domain/schemas/ministerioVoluntariosSchema.ts
@@ -10,6 +10,16 @@ export const minVoluntarioFuncaoSchema = z.object({
   status: z.enum(MinisterioVoluntarioFuncaoStatusEnum).optional(),
 });
 
+// Schema do formulário transiente de adicionar/editar função (FormModal). Ao adicionar,
+// o campo `id` aceita várias funções de uma vez (array); ao editar uma função já
+// associada, continua sendo uma única string — igual a minVoluntarioFuncaoSchema.
+export const minVoluntarioFuncaoModalSchema = z.object({
+  id: z.union([z.string('Campo obrigatório'), z.array(z.string()).min(1, 'Campo obrigatório')]),
+  nome: z.string().optional(),
+  experiencia: z.enum(EscalaTemplateExperienciaEnum, 'Campo obrigatório'),
+  status: z.enum(MinisterioVoluntarioFuncaoStatusEnum).optional(),
+});
+
 export const minVoluntarioSchema = z.object({
   voluntarioId: z.uuid('Campo obrigatório'),
   voluntarioFoto: z.string().optional(),
@@ -21,3 +31,4 @@ export const minVoluntarioSchema = z.object({
 
 export type MinVoluntarioFormData = z.infer<typeof minVoluntarioSchema>;
 export type MinVoluntarioFuncaoFormData = z.infer<typeof minVoluntarioFuncaoSchema>;
+export type MinVoluntarioFuncaoModalFormData = z.infer<typeof minVoluntarioFuncaoModalSchema>;

--- a/hooks/useChangelog.ts
+++ b/hooks/useChangelog.ts
@@ -1,0 +1,78 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Application from 'expo-application';
+import Constants from 'expo-constants';
+import { CHANGELOG, ChangelogEntry } from '../constants/changelog';
+
+const STORAGE_KEY = 'artos_changelog_last_seen_version';
+
+function getCurrentVersion(): string {
+  return Application.nativeApplicationVersion || Constants.expoConfig?.version || '0.0.0';
+}
+
+function compareVersions(a: string, b: string): number {
+  const partsA = a.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const partsB = b.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const length = Math.max(partsA.length, partsB.length);
+
+  for (let i = 0; i < length; i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff > 0 ? 1 : -1;
+  }
+
+  return 0;
+}
+
+async function getLastSeenVersion(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+async function setLastSeenVersion(version: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, version);
+  } catch {
+    // ignore
+  }
+}
+
+export type PendingChangelog = {
+  currentVersion: string;
+  entries: ChangelogEntry[];
+};
+
+/**
+ * Resolve o changelog pendente (versões novas desde a última vista) e já marca
+ * a versão atual como vista — chame uma única vez por sessão de app aberto.
+ *
+ * Instalação nova (sem versão anterior registrada) nunca mostra changelog: só
+ * grava a versão atual como vista, pra não parecer uma tela de "boas-vindas"
+ * incorreta pra quem está instalando o app pela primeira vez.
+ */
+export async function resolvePendingChangelog(): Promise<PendingChangelog | null> {
+  const currentVersion = getCurrentVersion();
+  const lastSeenVersion = await getLastSeenVersion();
+
+  if (lastSeenVersion === null) {
+    await setLastSeenVersion(currentVersion);
+    return null;
+  }
+
+  if (compareVersions(currentVersion, lastSeenVersion) <= 0) {
+    return null;
+  }
+
+  const entries = CHANGELOG.filter(
+    (entry) =>
+      compareVersions(entry.version, lastSeenVersion) > 0 &&
+      compareVersions(entry.version, currentVersion) <= 0,
+  ).sort((a, b) => compareVersions(b.version, a.version));
+
+  await setLastSeenVersion(currentVersion);
+
+  if (entries.length === 0) return null;
+
+  return { currentVersion, entries };
+}

--- a/hooks/useRepertorio.ts
+++ b/hooks/useRepertorio.ts
@@ -103,5 +103,9 @@ export function useYoutubeVersionSearch(query?: string, enabled = true, limit = 
     enabled: !!igrejaAtiva && enabled && normalizedQuery.length >= 2,
     queryFn: () =>
       RepertorioRepository.searchYoutubeVersions(igrejaAtiva!.id, normalizedQuery, limit),
+    // A chave de API do YouTube é compartilhada por todas as igrejas — retentar
+    // automaticamente (padrão do react-query: 3x com backoff) contra um 429 de rate
+    // limit só multiplica chamadas durante a janela de bloqueio e piora o problema.
+    retry: false,
   });
 }

--- a/utils/toast_config.tsx
+++ b/utils/toast_config.tsx
@@ -25,7 +25,11 @@ export function createToastConfig(palette: ThemePalette): ToastConfig {
         }}
         color={palette.confirm}
         lightColorPercent={64}
-        backgroundColor={isDarkPalette ? ColorUtils.withAlpha(palette.confirm, 0.34) : undefined}
+        backgroundColor={
+          isDarkPalette
+            ? ColorUtils.blendOver(palette.confirm, 0.34, palette.backgroundColor2)
+            : undefined
+        }
       />
     ),
     error: (props: ToastConfigParams<any>) => (
@@ -46,7 +50,11 @@ export function createToastConfig(palette: ThemePalette): ToastConfig {
         }}
         color={palette.error}
         lightColorPercent={42}
-        backgroundColor={isDarkPalette ? ColorUtils.withAlpha(palette.error, 0.34) : undefined}
+        backgroundColor={
+          isDarkPalette
+            ? ColorUtils.blendOver(palette.error, 0.34, palette.backgroundColor2)
+            : undefined
+        }
       />
     ),
     info: (props: ToastConfigParams<any>) => (
@@ -66,7 +74,11 @@ export function createToastConfig(palette: ThemePalette): ToastConfig {
         }}
         color={palette.primary}
         lightColorPercent={38}
-        backgroundColor={isDarkPalette ? ColorUtils.withAlpha(palette.primary, 0.34) : undefined}
+        backgroundColor={
+          isDarkPalette
+            ? ColorUtils.blendOver(palette.primary, 0.34, palette.backgroundColor2)
+            : undefined
+        }
       />
     ),
   };


### PR DESCRIPTION
11 commits, 30/08: fundo do toast opaco no dark mode, transição do avatar fallback, rate limit do YouTube em repertório, espaçamento do banner de tutorial, responsável do setlist condicionado ao tipo de ministério, code review da tela Setlist, múltiplas funções ao integrante, changelog in-app, seleção de ministérios no convite, horário de ensaio por ministério. Aberta pra preservar — merge fica pra quando a versão for organizada.