### PR TITLE
docs: design-system — Saúde do Voluntariado, Checklist

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -903,10 +903,85 @@ Ramo A concluído (cor + tipografia + componentes aprovados) — implementar no 
 | Gráfico único com 2 barras (Escalas+Horas) no mesmo eixo                   | Escalas muito diferentes (contagem vs. duração) mentiriam num eixo compartilhado — nunca eixo duplo (`dataviz`) |
 | Anel proporcional (X de 5) ou cor-por-estado no avatar de Integrantes      | Rejeitados em favor do ponto binário — mais simples de ler numa lista densa, deliberadamente distinto do selo multi-ícone do Painel Admin da Plataforma |
 
+## Direção visual (`trfernandes-atelier-explore` Ramo A — aprovada 2026-08-24)
+
+> Fidelidade escolhida: **Artifact único** (protótipo HTML), não rota real no projeto — os mockups
+> já usavam tokens/fontes/formato de componente reais desde a 3ª rodada de refinamento do concept,
+> então as 3 camadas foram formalizadas em cima do artifact existente
+> (`https://claude.ai/code/artifact/55167dea-7650-4513-9905-99d1272ef318`), sem recomeçar do zero.
+
+### Cor
+
+| Papel                                     | Token                          | Hex (light)          | Hex (dark)      |
+| ------------------------------------------ | ------------------------------ | --------------------- | ---------------- |
+| Identidade da seção Saúde (borda/tab ativa) | `palette.secondary`            | `#8E44AD`             | `#8E44AD`        |
+| Gráfico — série "Escalas"                 | `palette.primary`              | `#3B82F6`              | `#3B82F6`         |
+| Gráfico — série "Horas"                   | `palette.secondary`            | `#8E44AD`              | `#8E44AD`         |
+| Estado "atenção" (badge, label, threshold) | novo — `warning-text`         | `#8a5a00` (escurecido) | `#F5A623` (puro) |
+| Estado "bom/tratado"                       | `palette.confirm`              | `#228B22`              | `#228B22`         |
+
+- `primary`/`secondary` como ordem categórica fixa dos gráficos (nunca cycled) — validado via
+  `validate_palette.js`: CVD ΔE 12.0 (deutan)/19.2 (normal) entre o par, ambos acima do piso de
+  8/15.
+- `warning`/`confirm` são cores de **estado**, nunca identidade de série — reforça a regra do
+  `dataviz` (status colors reservadas).
+- **Achado corrigido nesta rodada**: o ponto de notificação da aba (`badge`) e os labels de atenção
+  (`acomp-state.wait`/`.reopen`, threshold do gráfico) usavam `warning` puro ou um hex hardcoded
+  (`#8a5a00`) sem variante dark. `warning` puro (`#F5A623`) contra o fundo claro
+  (`app-bg2`/`#F2F2F7`) mede **1.82:1**, abaixo do piso de 3:1 pra componente de UI. Fix: token novo
+  `--warning-text`, tema-aware — `#8a5a00` no claro (5.31:1 contra `#F2F2F7`) e `warning` puro no
+  escuro (8.59:1 contra `#1A1A1A` — o próprio `#8a5a00` falha no escuro, 2.94:1). Aplicado nos 3
+  lugares que usavam o hex solto.
+
+### Tipografia
+
+Nenhuma fonte nova — Montserrat via `FancyText`, já fixo no app inteiro.
+
+| Elemento                                  | Tamanho/peso aproximado (`FancyText` size/type) |
+| ------------------------------------------ | ------------------------------------------------ |
+| Título de card (ex: "Louvor", nome do bloco) | ~12.5px / bold                                  |
+| Corpo / frase de leitura direta            | ~11px / medium-semiBold                          |
+| Label micro (uppercase, pin/tag)           | ~8.5-9.5px / bold                                |
+| Valor direto no gráfico (barra/linha)      | ~8px / bold                                      |
+| CTA / botão                                | ~11.5px / bold                                   |
+
+### Componentes
+
+- **"Recibo de Cuidado"** (elemento-assinatura, sistematizado): bloco de Acompanhamento (4 estados
+  — calm/wait/done/reopen, cada um com cor de fundo tintada + label de estado) + botão "já tratei"
+  como par inseparável — nunca um sem o outro.
+- **Card de Saúde** (`health-card`): borda `secondary` 1.5px + fundo tintado `secondary` 6-8% —
+  container-base reutilizado por todo bloco novo desta feature (gráfico, timeline, colapsável,
+  acompanhamento), nunca um card genérico do app.
+- **Timeline vertical**: trilha lateral + pontos (calm=`confirm`, ativo=`secondary`,
+  ação=`secondary` preenchido) + data + frase — substitui o card de frases horizontal descartado.
+- **Card colapsável "como funciona"**: ícone circular "?" + título + chevron + corpo expansível —
+  substitui a tela cheia dedicada.
+- **Toggle Escalas/Horas**: par de pills, ativa em `secondary` sólido — reaproveita o mesmo formato
+  de pílula das abas (`FancyTabHeaderItem`), não um segmented control novo.
+- **Ponto binário no avatar** (Integrantes): dot 8-10px, cor `warning-text`, anel na cor do fundo —
+  presença/ausência, sem informação de tipo/quantidade.
+
+### Motivo gráfico — "Trilha do Cuidado"
+
+Derivado da linha do tempo vertical (trilha + pontos), o motivo se repete em 3 lugares
+estruturalmente diferentes: (1) a trilha de tendência dentro do card de sobrecarga (2 pontos,
+trimestre anterior/agora), (2) a linha do tempo vertical completa (N pontos, histórico de eventos),
+(3) o ponto binário isolado no avatar de Integrantes (1 ponto, sem trilha — a forma reduzida ao
+mínimo). Não é decorativo — é o mesmo vocabulário visual (ponto = evento/estado num percurso de
+cuidado) em 3 densidades de informação diferentes.
+
+### Inventário de gráficos e ilustrações
+
+| Gráfico/ilustração                              | Forma escolhida                          | Justificativa                                                                 |
+| ------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------- |
+| Mini-preview do Dashboard (Escalas + Sinais ativos) | Linha dupla normalizada + legenda         | 2 séries de unidades diferentes; normalização mostra forma da tendência sem eixo duplo enganoso |
+| "Nível de sobrecarga" (Escalas/Horas)             | Barra (com toggle de métrica)              | Contagem/duração discretas por mês — barra é a forma correta pra magnitude discreta, nunca linha |
+| Linha de referência "ritmo de atenção"             | Linha tracejada + label                    | Threshold real do domínio (12 escalas/3 meses) precisa ser lido junto ao dado, não só documentado à parte |
+| Timeline vertical                                 | Trilha + pontos + frase                    | Sequência de eventos datados — forma de linha do tempo, não lista genérica     |
+| Ponto binário no avatar                           | Dot simples                                | Presença/ausência é dado categórico, não vale a pena gráfico de forma mais rica pra isso |
+
 ## Próximo passo
 
-Conceito fechado e aprovado pelo usuário — bora pra cor/tipografia/componentes
-(`trfernandes-atelier-explore`, Ramo A), usando só os tokens reais já usados nos mockups desta
-sessão (`usePallete()`/`constants/colors.ts` — `secondary` como identidade da seção Saúde,
-`primary`/`secondary`/`terciary` como ordem categórica dos gráficos, `warning`/`confirm` reservados
-pra estado).
+Ramo A concluído (cor + tipografia + componentes aprovados, achado de contraste corrigido) — rodar
+`trfernandes-atelier-audit` antes de prosseguir.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -981,7 +981,72 @@ cuidado) em 3 densidades de informação diferentes.
 | Timeline vertical                                 | Trilha + pontos + frase                    | Sequência de eventos datados — forma de linha do tempo, não lista genérica     |
 | Ponto binário no avatar                           | Dot simples                                | Presença/ausência é dado categórico, não vale a pena gráfico de forma mais rica pra isso |
 
+## Audit Log
+
+### Audit — 2026-08-25
+
+#### Critérios de originalidade
+
+- [1] Troca de logo: ✅ — a trilha de pontos, a linha do tempo vertical e o Recibo de Cuidado
+  carregam a estrutura de cuidado pastoral independente de qualquer cor/logo de marca.
+- [2] Industry scan: ✅ — nenhum concorrente de gestão de voluntários usa "voluntário como canal
+  primário" (mesmos dados chegam pro voluntário antes/junto do líder) nem confirmação sentida
+  ("recibo de cuidado") no lugar de alerta de risco pro gestor.
+- [3] Tells de IA: ❌ encontrado e corrigido nesta rodada — avatar usava
+  `linear-gradient(secondary, primary)` como placeholder de foto, fora dos 4 contextos de gradiente
+  permitidos pelo `CLAUDE.md` (auth/drawer-header/dashboard/quiz-vendas). Trocado por fundo neutro
+  sólido (`app-bg3` + borda). Pesos de fonte: só 3 distintos (500/600/700) — dentro do limite de 4.
+- [4] Especificidade do domínio: ✅ — estrutura (eixos de sobrecarga, sinais de cuidado, recibo,
+  toggle Escalas/Horas com o threshold real de 12 escalas/3 meses) não serviria pra outro domínio
+  sem alteração de dados exibidos.
+- [5] Decisão vs default: ✅ — cor principal (`secondary`), tipografia (Montserrat/escala
+  documentada) e densidade (1 card por bloco, scroll em vez de acordeão denso) são decisões
+  registradas com motivo em "Direção visual" acima, não primeiro valor.
+- [6] Riqueza gráfica: ✅ — 3 gráficos com forma escolhida pelo tipo de dado (barra pra
+  contagem/duração discreta, linha normalizada pro mini-preview, linha tracejada de threshold real)
+  + motivo gráfico próprio ("Trilha do Cuidado") aplicado em 3 lugares estruturalmente diferentes.
+
+#### Contraste
+
+- Branco sobre `secondary` (tab ativa, botão primary): 5.87:1 — ✅ AA.
+- `secondary` sobre branco (labels, título de card, botão outline): 5.87:1 — ✅ AA.
+- `font-dark` (#3E3E3E) sobre branco: 10.70:1 — ✅ AAA.
+- **`warning` puro (#F5A623) sobre fundo claro (branco/`app-bg2`), usado como cor de UI
+  (badge/dot/linha de threshold): 1.82–2.03:1 — ❌ falha o piso de 3:1 pra componente de UI.**
+  Encontrado em 3 lugares que sobreviveram à correção inicial da camada de cor: `.badge` (aba com
+  notificação), `.avatar .dot` (indicador individual de Integrantes — o componente central desta
+  entrega), e a linha tracejada de threshold do gráfico. Corrigido nesta auditoria: todos os 3 agora
+  usam `--warning-text` (`#8a5a00` no claro, 5.31:1 — ✅; `warning` puro no escuro, 8.59:1 — ✅).
+- `primary` (#3B82F6) como marca gráfica (barra do gráfico "Nível de sobrecarga"): 3.68:1 sobre
+  branco — ✅ acima do piso de 3:1 pra elemento gráfico não-textual.
+- `terciary` (#F67E3B) como marca gráfica (linha "Sinais ativos" no mini-preview do dashboard):
+  2.64:1 sobre branco — ⚠️ abaixo do piso de 3:1, mas mitigado pela legenda com **texto visível**
+  (não só cor), que é a exceção documentada no `dataviz` (skill): "uma WARN de contraste obriga
+  label visível ou tabela — não é dispensável". Já implementado desde a criação do mini-preview.
+  Validado via `validate_palette.js` (`primary,secondary,terciary` — CVD ΔE 12.0/19.2, ambos acima
+  do piso).
+- `confirm` (#228B22) em chip/estado "tratado"/"calm": mesmo padrão já confirmado em uso no resto do
+  app (ex: `EscalaHeader`), sem uso novo fora do já auditado anteriormente.
+
+#### Consistência interna
+
+- Zero hex hardcoded fora de definição de token — checado via grep no artifact final; único hex
+  "solto" restante é o fallback JS (`|| '#3B82F6'` etc.), padrão aceitável de fallback, não
+  hardcode real.
+- Componentes replicam o formato real do app: `DashboardCard` (squircle + valor + label),
+  `FancyListStats` (pill com borda/sombra), `FancyTabHeaderItem` (pílula ativa sólida) — confirmado
+  contra os arquivos reais lidos nesta sessão, não suposição.
+- Raio de borda (16px cards, 999px pílulas) e sombra (`--shadow`, equivalente a `shadows[200]`)
+  batem com o padrão já confirmado no app (`DashboardCard.tsx`, `FancyListStats.tsx`).
+- Tipografia (3 pesos, Montserrat) consistente com a escala fixa do app — nenhuma fonte nova.
+
+#### Débito de design
+
+- Nenhum — os 2 achados reais (contraste do indicador binário/threshold, gradiente de avatar) foram
+  corrigidos nesta própria rodada de auditoria, não ficaram como débito.
+
 ## Próximo passo
 
-Ramo A concluído (cor + tipografia + componentes aprovados, achado de contraste corrigido) — rodar
-`trfernandes-atelier-audit` antes de prosseguir.
+Ramo A concluído e auditado — implemento no código real (`trfernandes-atelier-implement`)? Por ora
+segue pausado, aguardando a Landing de vendas (`diakonia-public-site`) fechar seu próprio ciclo de
+design antes de qualquer implementação (decisão do usuário: "implementar só no final").

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -710,6 +710,81 @@ lista compacto, a tela própria é o detalhe pra onde a navegação leva. O elem
 que muda de sentença, chip com dado real, esmaecido mas tocável) continua idêntico — só migrou de
 container (card expansível → tela).
 
+## Direção visual (trfernandes-atelier-explore Ramo A — aprovado 2026-08-21)
+
+### Cor — Variante F ("cada passo com sua cor")
+
+Cada passo do checklist recebe uma cor de "competência" própria, emprestada do sistema de cores
+de seção do repertório (`utils/secaoCores.ts`) — nenhuma dessas cores passa por `usePallete()`,
+foi um achado explícito pedido pelo usuário depois de reprovar as 3 primeiras variantes (cinza
+demais, verde feio). Ao resolver, cada passo converge pra esmeralda (`statusThemes.ts`,
+tema `APPROVED`/`ATIVO`), também fora do `usePallete()`.
+
+| Papel | Claro | Escuro | Origem |
+| --- | --- | --- | --- |
+| Passo "Funções cadastradas" | `#0EA5A5` | `#2DD4D4` | `secaoCores.ts` (seção Instrumental) |
+| Passo "Voluntários vinculados" | `#6D5EF3` | `#8C7EF7` | `secaoCores.ts` (seção Ponte) |
+| Passo "Função atribuída" | `#E67E22` | `#F0954A` | `secaoCores.ts` (seção Solo) |
+| Resolvido / conquista | borda `#059669` · destaque `#10B981` | borda `#10B981` · destaque `#34D399` | `statusThemes.ts` (APPROVED/ATIVO) |
+| CTA ("Continuar configuração") | `palette.primary` (`#3B82F6`) | idem | `usePallete()` — **não muda por feature**, regra já documentada acima |
+| Texto/legenda/esmaecido | `palette.fonts.dark` / `.inactive` / `.inactive2` | idem | `usePallete()` |
+
+Correção registrada durante a camada de componentes: o CTA tinha sido desenhado em teal por
+engano — corrigido pra `palette.primary` porque a regra "botão principal = CTA sólido" não varia
+por feature (só ícone/chip/indicador tem liberdade de cor própria).
+
+### Tipografia — "Hero de impacto"
+
+Nenhuma fonte nova (app inteiro usa Montserrat). Escala de 3 níveis, toda reaproveitada de
+`constants/font.ts` / `FancyText`:
+
+| Elemento | Token | px | Peso |
+| --- | --- | --- | --- |
+| Frase de status (elemento-assinatura, hero da tela própria) | `size='titleLarge'` | 22 | bold |
+| Título do passo | `size='mediumLarge'` | 14 | semiBold |
+| Legenda do passo / subtítulo do hero | `size='extraSmall'`/`'small'` | 11-12 | medium |
+| Título do teaser (card na listagem) | `size='small'` | 12 | bold |
+| Chip resolvido | preset `medium` de `FancyChips` | ~12 | bold |
+
+`titleLarge` não tinha uso em produção antes desta tela — precedente parcial em `DashboardCard`
+(`size='title'`, 20px, pra número de destaque); aqui sobe um nível porque a frase É o motivo da
+tela existir, não um dado secundário dentro de um card.
+
+### Componentes
+
+- **Teaser do Checklist** (novo, na listagem de escalas): reaproveita a linguagem visual de
+  `FancyListItemCard` (raio 18, `shadows[200]`, borda 0.5 @ 45% alpha) — ícone 34px + frase de
+  status (12px bold) + legenda (11px) + chevron. Sem os 3 passos aqui; toque navega pra tela
+  própria do Checklist.
+- **Step Row** (elemento-assinatura sistematizado, dentro da tela própria do Checklist): ícone
+  24-38px na cor do passo (16% alpha, 10% quando esmaecido, esmeralda quando resolvido) + label
+  14px semiBold + legenda 11px + chip esmeralda com dado real (resolvido) ou seta `›` (não
+  resolvido, sempre tocável mesmo esmaecido). Linha inteira tocável, sem `FancyButton` dentro.
+- **Modal de pré-checagem**: `FancyBottomSheetModal` — **revisão da decisão original do conceito**
+  (que previa `FancyModalDialog`, diálogo centralizado). Apareceu como bottom sheet por engano
+  num mockup da camada de cor; o usuário revisou e preferiu manter bottom sheet depois de ver as
+  duas opções lado a lado na camada de componentes. Botões empilhados (não lado a lado): "Gerar
+  mesmo assim" (contained, `primary`) em cima, "Revisar checklist" (outlined) embaixo — segue a
+  hierarquia já documentada (1 contained por contexto).
+
+### Motivo gráfico — "Selo de Etapa"
+
+Cada competência de configuração (função / vínculo / atribuição) ganha um selo colorido próprio
+(ícone dentro de um quadrado arredondado com fundo tintado) que muda de cor pra esmeralda só
+quando a etapa é conquistada — não é decoração, é o mecanismo central de leitura do checklist.
+Aplicado em 3 lugares estruturalmente diferentes: (1) ícone do teaser compacto na listagem, (2)
+ícone de cada `Step Row` na tela própria, (3) cor do chip de dado real quando resolvido. Deriva
+do sistema de cores por seção que já existe no repertório musical do app (`secaoCores.ts`) —
+mesma lógica de "cada categoria tem sua identidade visual", aplicada agora a etapas de
+configuração em vez de seções de música.
+
+### Estrutura de telas (revisão 2026-08-21, ver acima)
+
+Teaser compacto na listagem de escalas → navega pra tela própria "Checklist" (não expande
+in-place) → tela mostra os 3 `Step Row` completos → modal `FancyBottomSheetModal` intercepta o
+botão "Gerar" do Assistente (`assistant.tsx`), nunca bloqueia (ADR 0003).
+
 ## Próximo passo
 
-Cor/tipografia/componentes reais — `trfernandes-atelier-explore` Ramo A.
+Ramo A concluído (cor + tipografia + componentes aprovados) — implementar no código real
+(`trfernandes-atelier-implement`).

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -789,3 +789,124 @@ do Assistente (`assistant.tsx`), nunca bloqueia (ADR 0003).
 
 Ramo A concluído (cor + tipografia + componentes aprovados) — implementar no código real
 (`trfernandes-atelier-implement`).
+
+---
+
+# Design System — Saúde do Voluntariado (escopo: Sobrecarga/Saúde do Voluntariado)
+
+> Escopo: card "Meu Ritmo de Serviço" no Dashboard (Início), aba "Saúde" no perfil do voluntário
+> (Integrantes → Detalhes), aba espelho "Minha Saúde" na tela Pessoal, indicador individual e pill
+> agregado em Integrantes, tela "Como funciona" (substituída por card colapsável). Estrutura
+> funcional já fechada via grilling anterior (ver CONTEXT.md e
+> `docs/plans/2026-08-17-plano-versao-2.md` seção 3, branch `1.2`) — esta sessão fechou o conceito
+> visual/estrutural formal. Revisão: 2026-08-24 —`trfernandes-atelier-concept`, refinado em 3
+> rodadas de `/grill-me` pós-wireframe.
+
+## Conceito
+
+- **Paradigma**: Voluntário como canal primário — inversão do dashboard-de-vigilância padrão. Em
+  vez do Líder monitorar o voluntário de fora, os mesmos dados de saúde chegam primeiro (ou junto)
+  pro próprio voluntário, na primeira pessoa; o Líder vê uma derivação dessa mesma visão, nunca uma
+  visão exclusiva/superior. Resolve a tensão "cuidado vs. vigilância" na própria estrutura de
+  dados, não só no tom.
+- **Estrutura OOUX**:
+  - Card de saúde (Líder/Admin, Dashboard) → card compacto dentro de uma `DashboardSection` própria
+    ("Meu Ritmo de Serviço"), mini-gráfico de linha dupla normalizada (Escalas + Sinais ativos) com
+    legenda, toque abre o drill-down.
+  - Aba "Saúde" (perfil do voluntário, Integrantes) → nova aba em pílula ao lado de "Dados" e
+    "Scores" (mesmo componente de abas já existente no app, cor ativa trocada pra `secondary`),
+    contendo: card colapsável "como funciona" → card único "Nível de sobrecarga" (toggle
+    Escalas/Horas, substitui os antigos 2 blocos separados) → linha do tempo vertical (histórico de
+    eventos) → bloco de Acompanhamento (4 estados).
+  - Aba "Minha Saúde" (tela Pessoal) → espelho exato da aba Saúde do Líder (mesmo componente,
+    mesmos gráficos, mesma linha do tempo vertical), sem o card colapsável (já visto), com o CTA
+    "quero conversar sobre minha carga" no fim.
+  - Indicador individual (Integrantes, listagem) → ponto binário no avatar (não anel
+    multi-informação — deliberadamente mais simples que o selo de severidade do Painel Admin da
+    Plataforma, outro produto/contexto).
+  - Insight agregado (Integrantes, topo da lista) → 1 pill a mais ("ATENÇÃO: N") dentro da mesma
+    fileira de stats que já existe (Total/Ativos/Inativos), sem criar linha nova na tela.
+  - Tela "Como funciona" dedicada → **eliminada**; vira card colapsável no topo da aba Saúde.
+- **Elemento-assinatura**: **"Recibo de Cuidado"** — quando o Líder marca "já tratei" no bloco de
+  Acompanhamento, o próprio Voluntário recebe uma confirmação visível de que foi visto ("seu líder
+  viu isso e está com você") — não uma notificação genérica de sistema, uma marca de presença
+  humana. Regra estrutural inversa que reforça o mesmo princípio: qualquer sinal automático só
+  aparece pro Líder depois que o Voluntário já teria tido chance de vê-lo primeiro (canal primário
+  = voluntário). Aplicado em 3 lugares estruturalmente diferentes: botão "já tratei" (Líder), bloco
+  de recibo (Voluntário), histórico de recibos na linha do tempo (Voluntário).
+- **Gate Jakob**: passou — trocando logo/cor por um concorrente genérico de gestão de voluntários,
+  a linha do tempo vertical narrada, o recibo de cuidado, o gráfico honesto sem eixo duplo e a
+  simetria estrutural Líder/Voluntário (mesma aba, não visão reduzida) ainda seriam reconhecíveis
+  como uma estrutura específica de acompanhamento pastoral — nenhum é o default de dashboard de RH
+  (card+KPI+alerta pro gestor, sem narrativa nem simetria).
+
+## Refinamentos pós-concept (3 rodadas de `/grill-me`, mesma sessão)
+
+1. **Wireframe precisa de contexto real** — 1ª e 2ª rodadas: wireframe cinza abstrato e depois
+   blocos sem a tela ao redor não permitiam julgar o resultado. Fix: todo wireframe subsequente
+   mostra os blocos novos dentro da tela real do app (Início, Integrantes, perfil, Pessoal), com o
+   que já existe hoje marcado (cinza tracejado/esmaecido) e o novo destacado.
+2. **Visual precisa ser próximo do real, não wireframe cinza** — 3ª rodada trocou JetBrains
+   Mono/IBM Plex Sans/tokens cinza por Montserrat + cores reais de `constants/colors.ts` +
+   formato real dos componentes (`DashboardCard`, `FancyListStats`, abas em pílula tipo
+   `FancyTabHeaderItem`).
+3. **Estados possíveis** — usuário pediu ver todos os cenários reais do domínio (não só o caso
+   "carga subindo"): eixos ativados, os 3 sinais adicionais, tendência de melhora, múltiplos sinais
+   simultâneos, e os 3 estados de acompanhamento — todos usando o mesmo card, variando só cor de
+   detalhe (confirm=bom, warning=atenção) e conteúdo.
+4. **`/grill-me` de 7 pontos** (rodada dedicada, ver histórico de conversa):
+   - Card do dashboard trocou seta+frase por gráfico real (mini-gráfico de linha dupla normalizada,
+     forma não valor exato).
+   - Aba Saúde ganhou gráficos reais de volume (escalas/horas) e nível de sobrecarga, com toggle de
+     período — depois consolidados num só gráfico (ver item 5 abaixo).
+   - Indicador individual de Integrantes definido como ponto binário no avatar (não anel
+     proporcional, não cor por estado — mais simples, decidido explicitamente contra as duas
+     alternativas mais ricas).
+   - Card "como funciona" virou colapsável no topo da aba, substituindo a tela cheia dedicada.
+   - Card de "acompanhamento" e "linha do tempo" viraram uma linha do tempo vertical com 9 tipos de
+     evento nomeados (eixo ativado/normalizado, sinal disparado/normalizado, ação do
+     voluntário/líder, reabertura) e 4 estados de Acompanhamento nomeados (sem sinal / aguardando /
+     tratado / reaberto).
+   - Tela Pessoal do Voluntário passou a espelhar exatamente os mesmos componentes do Líder (era um
+     card próprio, diferente e confuso).
+5. **Correção dataviz — eixo duplo em "Volume de serviço"**: usuário pediu unificar os 2 gráficos
+   de volume (Escalas + Horas) num só; como as duas métricas têm escalas numéricas muito diferentes
+   (~0-15 vs. ~0-40), um gráfico com 2 barras no mesmo eixo mentiria — resolvido com barra
+   empilhada por escala (altura total = horas, cada segmento = 1 escala, contagem anotada). Essa
+   versão foi substituída no refinamento seguinte (item 6) por um toggle, mas o princípio "nunca
+   eixo duplo" (`dataviz` skill) se manteve nas duas soluções.
+6. **"Sinais ativos" era confuso + pedido de toggle Escalas/Horas em "Nível de sobrecarga"**:
+   "Volume de serviço" e "Nível de sobrecarga" (que usava a métrica abstrata "sinais ativos", 0–5)
+   foram unificados numa seção só, com toggle **Escalas / Horas** (bar chart simples, cada visão
+   com a própria escala) — visão Escalas mantém a linha tracejada de referência ("ritmo de atenção
+   ~4/mês", equivalente ao limiar real do eixo de Escalas: 12 em 3 meses). O conceito de "sinais
+   ativos" (composto dos 2 eixos + 3 sinais) deixou de existir como gráfico — passou a viver só em
+   linguagem simples na linha do tempo e no indicador do avatar, renomeado para **"sinais de
+   cuidado"**.
+7. **Card do Dashboard revertido**: no meio do refinamento anterior a legenda do mini-gráfico do
+   Dashboard foi trocada de "Escalas + Sinais ativos" pra "Escalas + Horas" — usuário pediu reverter
+   explicitamente ("não era pra ter mexido no primeiro card"); card do Dashboard voltou a mostrar
+   Escalas + Sinais ativos, como no wireframe original aprovado. Regra prática: mudança de
+   vocabulário aprovada numa seção não se propaga automaticamente pra outra sem pedido explícito.
+8. **Verificação de fato (não decisão)**: confirmado em
+   `docs/plans/2026-08-17-plano-versao-2.md:251-252` que o sinal "Aumento de indisponibilidade" já
+   é relativo à média pessoal do próprio voluntário (≥2x a média dos últimos 6 meses), não um
+   limiar global — não precisou de nova decisão de design, só checagem do que já estava fechado.
+
+### Direções descartadas (concept)
+
+| Direção                                                                    | Motivo                                                                                                        |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Wireframe abstrato sem tela ao redor (v1 do concept)                       | Usuário não conseguia julgar o resultado sem ver o contexto real da tela — refeito mostrando app real ao redor |
+| Gesto de hold customizado (divergência SCAMPER)                           | Risco real de descoberta sem affordance visual (regra `platform-mobile.md`), sem ganho proporcional — descartado na síntese do concept |
+| Métrica "nível de sobrecarga" como composto abstrato 0–5 ("sinais ativos") | Usuário achou o termo confuso; substituído por toggle concreto Escalas/Horas + linha do tempo em linguagem simples |
+| Gráfico único com 2 barras (Escalas+Horas) no mesmo eixo                   | Escalas muito diferentes (contagem vs. duração) mentiriam num eixo compartilhado — nunca eixo duplo (`dataviz`) |
+| Anel proporcional (X de 5) ou cor-por-estado no avatar de Integrantes      | Rejeitados em favor do ponto binário — mais simples de ler numa lista densa, deliberadamente distinto do selo multi-ícone do Painel Admin da Plataforma |
+
+## Próximo passo
+
+Conceito fechado e aprovado pelo usuário — bora pra cor/tipografia/componentes
+(`trfernandes-atelier-explore`, Ramo A), usando só os tokens reais já usados nos mockups desta
+sessão (`usePallete()`/`constants/colors.ts` — `secondary` como identidade da seção Saúde,
+`primary`/`secondary`/`terciary` como ordem categórica dos gráficos, `warning`/`confirm` reservados
+pra estado).

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -617,3 +617,99 @@ estados positivos/finalizados.
 | --- | --- | --- | --- |
 | NotificationButton (badge) | 2026-08-17 | Número "13" estourava círculo em qualquer tamanho fixo testado | Trocado por dot 8px sem número |
 | NotificationButton + FancyHeader (avaliação livre) | 2026-08-17 | F1 (touch target <44px), F2 (posição do dot — rejeitado, não se aplica), F3 (alinhamento título — ok), F4 (tamanho do título — ok) | F1 registrado como débito; F2 rejeitado (R1); F3/F4 sem ação |
+
+---
+
+# Design System — Checklist de Configuração de Escala (escopo: tela/banner nova)
+
+> Escopo: banner + expansão na listagem de escalas do ministério (Fase 1 do roadmap Versão 2).
+> Revisão: 2026-08-19 — fluxo `trfernandes-atelier` completo (advise + grilling + concept).
+
+## Entendimento (advise + grilling, fechado com o usuário)
+
+- Banner aparece na listagem de escalas do ministério, **só quando o checklist está incompleto**
+  — pensado pro primeiro acesso (líder novo que já quer sair gerando escala sem ter configurado
+  nada). Também um item de menu na mesma tela, acessível a qualquer momento.
+- Admin usa a mesma visão do líder, ministério por ministério — sem tela agregada por igreja
+  nesta fase (`GET /igrejas/:id/checklist-escala` fica sem consumo no app por ora).
+- Pré-checagem intercepta automaticamente o botão "Gerar" no último passo do Assistente já
+  existente (`assistant.tsx`) — nunca bloqueia (ADR 0003), só avisa com opção "Gerar mesmo
+  assim".
+- Tela de uso raro (configuração, não daily driver).
+
+## Conceito
+
+- **Paradigma**: nenhum dos 12 paradigmas-padrão isolado — é essencialmente uma variação de
+  "Master-detail com preview inline" (item 7), mas com o preview substituindo o resultado
+  esperado ("check") por um **resultado real** (contagem) quando resolvido. Casa com a dimensão
+  dominante (estado de configuração, não dado temporal/espacial/conversa) e a restrição mobile
+  (baixa densidade, uma ação óbvia por vez, thumb zone).
+- **Estrutura OOUX**:
+  - `Passo do Checklist` (função/vínculo/função-do-voluntário) → não vira tela própria, nem
+    lista genérica com checkbox — vira **linha de estado** dentro de um card expansível na
+    listagem de escalas (ver Direção abaixo).
+  - `Checklist` (agregador dos 3 passos, por ministério) → não é tela própria nesta fase — é o
+    card/banner citado acima, aberto por toque ou pelo item de menu.
+  - `Pré-checagem` (por vaga/evento) → modal (`FancyModalDialog`), intercepta o botão "Gerar".
+  - `Função` (cadastro) → sem tela nova; reaproveita o cadastro de função já existente
+    (`ministerio-funcoes`), só ganha sugestões (catálogo) — decisão de onde vive o catálogo
+    ainda em aberto, não bloqueia o conceito de tela.
+- **Elemento-assinatura**: **"a frase que muda de sentença"** — no topo do card, uma única linha
+  de status narra o que falta em linguagem de domínio ("Falta cadastrar função" → "Falta
+  vincular voluntários" → "Falta atribuir função aos voluntários" → "Ministério pronto pra
+  escalar"), recalculada ao vivo conforme o líder resolve cada passo. Nunca frasa como
+  bloqueio/impedimento (ADR 0003: avisa, não bloqueia) — sempre framing de "falta X", nunca "não
+  pode Y".
+  - Item resolvido **não vira checkmark** — vira um chip com o dado real que foi criado (ex:
+    "4 funções", "9 voluntários"), reforçando "você construiu algo" em vez de "você marcou uma
+    tarefa".
+  - Item ainda não alcançável na ordem lógica (ex: atribuir função sem ter voluntário vinculado
+    ainda) fica visualmente esmaecido, mas **continua tocável** — nunca trava navegação
+    (consistente com "nunca bloqueia").
+  - Cada linha é tocável por inteiro (sem `FancyButton` dentro da linha) — toque no corpo da
+    linha navega pro cadastro correspondente.
+- **Gate da Lei de Jakob**: passou. Trocando cor/logo por um concorrente do mesmo segmento, a
+  estrutura ainda seria reconhecível — nenhum outro app de escala voluntária usa "frase de status
+  que narra o próximo passo em linguagem de domínio" + "chip de contagem real em vez de check" no
+  lugar do checklist genérico de onboarding.
+
+### Direções descartadas (subagentes paralelos, técnicas de divergência)
+
+| Direção | Técnica | Por que descartada (parcial) |
+| --- | --- | --- |
+| "GO/NO-GO de palco" (veredito bloqueante, itens com severidade) | Analogia forçada (backstage de show) | Framing "escala não pode ser gerada" contradiz ADR 0003 (nunca bloqueia) — mantida só a ideia de frase de status dinâmica, reescrita sem linguagem de bloqueio |
+| Cadeado que trava item 3 até 1+2 resolverem | Estratégia oblíqua (sem botão) | Lock literal implica bloqueio de navegação, que o produto não tem hoje — mantida só a ideia de linha inteira tocável (sem botão) e esmaecimento visual sem travar toque |
+| Trilha horizontal fixa de 3 estações | SCAMPER Eliminate | Estrutura de trilha não cabia bem no espaço de uma listagem de escalas (empurraria conteúdo real da tela) — mantida a ideia central (chip com contagem real em vez de check) |
+
+### Revisão 2026-08-21 — Checklist vira tela própria
+
+Durante a camada de cor (`trfernandes-atelier-explore` Ramo A), o usuário revisou um ponto do
+entendimento acima: o card/banner na listagem de escalas **continua existindo** como ponto de
+entrada (sugestão no primeiro acesso + item de menu), mas agora é só um **teaser compacto**
+(frase de status + indicador de toque) — ele não expande mais os 3 passos in-place. Tocar no
+teaser (ou no item de menu) **navega pra uma tela própria do Checklist**, que mostra os mesmos 3
+passos (mesmo conteúdo, mesmo elemento-assinatura "frase que muda de sentença" + chip com dado
+real), só que em tela cheia. Essa tela não tem entrada própria fora desses dois pontos — não vira
+destino de menu lateral nem tab, é alcançável só a partir da listagem de escalas do ministério.
+
+Cogitou-se também mostrar um card equivalente em Início (dashboard) — descartado pelo usuário
+("esqueci desse detalhe, esquece essa ideia"), fora de escopo desta fase.
+
+Isso muda a estrutura OOUX (linha 647-656 acima):
+- `Passo do Checklist` → continua **linha de estado**, mas agora dentro da tela própria, não do
+  card da listagem.
+- `Checklist` (agregador dos 3 passos) → **é tela própria** nesta fase (correção do texto
+  original acima, que dizia o contrário) — reaproveita a mesma linguagem visual e cores já
+  aprovadas (Variante F, ver seção Cor abaixo).
+- O card da listagem passa a ser só o `Teaser do Checklist` — objeto novo, compacto: mesma frase
+  de status como título, sem os 3 passos, com indicador de navegação (chevron).
+
+Paradigma ajustado: deixa de ser puramente "Master-detail com preview inline" (item 7) e passa a
+ser um híbrido com "Lista + detalhe" (item 1) — o teaser na listagem funciona como o item de
+lista compacto, a tela própria é o detalhe pra onde a navegação leva. O elemento-assinatura (frase
+que muda de sentença, chip com dado real, esmaecido mas tocável) continua idêntico — só migrou de
+container (card expansível → tela).
+
+## Próximo passo
+
+Cor/tipografia/componentes reais — `trfernandes-atelier-explore` Ramo A.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -29,19 +29,22 @@
 - Dimensão dominante: conversa/narrativa (carrossel guiado, não dados/tabela)
 - Contexto de uso: mobile em movimento, sessão de poucos minutos dentro do funil de cadastro
 
-## Features finais (5, aprovadas)
+## Features finais (6, aprovadas)
 
-| #   | category            | title                        | subtitle                                                                                     |
-| --- | ------------------- | ---------------------------- | -------------------------------------------------------------------------------------------- |
-| 1   | ESCALA AUTOMÁTICA   | A escala se monta sozinha    | Diakonia cruza disponibilidade e função de cada voluntário e monta a escala pra você.        |
-| 2   | SEM FURO NA ESCALA  | Substituição sem correria    | Voluntário indisponível? O app avisa o líder e já sugere quem pode entrar no lugar.          |
-| 3   | LEMBRETE AUTOMÁTICO | Ninguém esquece a escala     | Notificação automática avisa cada voluntário — acabou o lembrete manual por WhatsApp.        |
-| 4   | DISPONIBILIDADE     | Avisar que não pode é rápido | Voluntário marca os dias indisponíveis direto no app, sem precisar avisar ninguém um por um. |
-| 5   | REPERTÓRIO          | Repertório sempre à mão      | Músicas, tom e ordem organizados por ministério, prontos pra ensaio.                         |
+| #   | category                   | title                                     | subtitle                                                                                                             |
+| --- | -------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 1   | ESCALA AUTOMÁTICA          | A escala se monta sozinha                 | Diakonia cruza disponibilidade e função de cada voluntário e monta a escala pra você.                                |
+| 2   | SEM FURO NA ESCALA         | Substituição sem correria                 | Voluntário indisponível? O app avisa o líder e já sugere quem pode entrar no lugar.                                  |
+| 3   | LEMBRETE AUTOMÁTICO        | Ninguém esquece a escala                  | Notificação automática avisa cada voluntário — acabou o lembrete manual por WhatsApp.                                |
+| 4   | DISPONIBILIDADE            | Avisar que não pode é rápido              | Voluntário marca os dias indisponíveis direto no app, sem precisar avisar ninguém um por um.                         |
+| 5   | REPERTÓRIO                 | Repertório sempre à mão                   | Músicas, tom e ordem organizados por ministério, prontos pra ensaio.                                                 |
+| 6   | CUIDADO COM O VOLUNTARIADO | Você percebe quando alguém está no limite | Diakonia avisa o líder quando um voluntário está servindo demais ou dando sinais de cansaço — antes que ele desista. |
 
 Decisão anterior tinha só 3 features genéricas ("Tudo num só lugar" era um catch-all fraco); revisão
 trocou por 5 funcionalidades reais e específicas do produto, com frases descrevendo a situação
-concreta que cada uma resolve.
+concreta que cada uma resolve. Item 6 adicionado em grilling 2026-08-22 (feature de Sobrecarga/Saúde
+do Voluntariado, ver `docs/plans/2026-08-17-plano-versao-2.md` seção 3 na branch `1.2`) — único
+diferencial de cuidado emocional/pastoral do carrossel, os outros 5 são todos logística de escala.
 
 ## Referências
 
@@ -94,6 +97,9 @@ interface/celular fazendo a coisa acontecer, não alguém segurando o celular.
   - Feature 3 (Lembrete automático) — `Pallete.primary` (azul)
   - Feature 4 (Disponibilidade) — `Pallete.confirm` (verde)
   - Feature 5 (Repertório) — `Pallete.warning` (amarelo)
+  - Feature 6 (Cuidado com o Voluntariado) — cor e ilustração ainda não definidas (slide adicionado
+    2026-08-22, depois desta direção visual já fechada) — decidir numa sessão
+    `trfernandes-atelier-explore` própria antes de implementar.
   - Conclusão — `Pallete.confirm` (verde, "problema resolvido")
 - Contraste: cores de accent usadas só em onda/categoria/progress (nunca texto de corpo), que
   continua em `fonts.dark`/`fonts.inactive` — sem risco de AA.
@@ -296,8 +302,7 @@ estados positivos/finalizados.
 # Design System — Indisponibilidades por Ministério (escopo: correção visual)
 
 > Escopo: `app/(app)/(drawer)/ministerios/indisponibilidades/index.tsx` +
-> `components/list/FancyListEmpty.tsx` (nova prop `variant`).
-> Revisão: 2026-08-05
+> `components/list/FancyListEmpty.tsx` (nova prop `variant`). Revisão: 2026-08-05
 
 ## Regras de Design Confirmadas
 
@@ -313,16 +318,15 @@ estados positivos/finalizados.
   fica fisicamente onde a ação se aplica.
 - **[confirmed 2026-08-05]** Agrupamento de seção dentro de tela usa card:
   `backgroundColor: palette.backgroundColor2`, `borderWidth: 0.5`,
-  `borderColor: ColorUtils.withAlpha(palette.borderCard, 0.45)`, `borderRadius: 16`,
-  `padding: 15`, `...palette.shadows[200]`. Confirmado em `configuracoes/index.tsx:1723-1734`
-  (`heroStatCard`). Primeira tentativa (mesma rodada) saiu com `borderWidth: 1` e sem sombra —
-  corrigido após o usuário apontar que o card não batia com o design system; a sombra é obrigatória
-  no padrão de card do app (checklist do `CLAUDE.md`: "sombra via `Pallete.shadows`, nunca
-  `elevation` direto"). Tela Indisponibilidades não aplicava nada disso — os 3 blocos
-  (calendário+legenda, bloqueios pessoais, regras deste ministério) eram `View` soltas sem
-  background/border/sombra, só separadas por `FancyVerticalSpacer`. Fix: cada bloco vira um card
-  nesse padrão; legenda entra dentro do card do calendário (hoje solta, lida como bloco próprio em
-  vez de explicação do gráfico acima dela).
+  `borderColor: ColorUtils.withAlpha(palette.borderCard, 0.45)`, `borderRadius: 16`, `padding: 15`,
+  `...palette.shadows[200]`. Confirmado em `configuracoes/index.tsx:1723-1734` (`heroStatCard`).
+  Primeira tentativa (mesma rodada) saiu com `borderWidth: 1` e sem sombra — corrigido após o
+  usuário apontar que o card não batia com o design system; a sombra é obrigatória no padrão de card
+  do app (checklist do `CLAUDE.md`: "sombra via `Pallete.shadows`, nunca `elevation` direto"). Tela
+  Indisponibilidades não aplicava nada disso — os 3 blocos (calendário+legenda, bloqueios pessoais,
+  regras deste ministério) eram `View` soltas sem background/border/sombra, só separadas por
+  `FancyVerticalSpacer`. Fix: cada bloco vira um card nesse padrão; legenda entra dentro do card do
+  calendário (hoje solta, lida como bloco próprio em vez de explicação do gráfico acima dela).
 
 ## Direção visual — Componentes (aprovada)
 
@@ -343,27 +347,29 @@ estados positivos/finalizados.
   pessoal / regra de ministério), nada genérico introduzido.
 - [5] Decisão vs default: ✅ — `variant='compact'` e reposicionamento do FAB são decisões
   registradas com motivo acima, não primeiro valor.
-- [6] Riqueza gráfica: N/A — correção de layout, não tela nova; sem expectativa de gráfico/ilustração.
+- [6] Riqueza gráfica: N/A — correção de layout, não tela nova; sem expectativa de
+  gráfico/ilustração.
 
 ### Contraste
 
-- `fonts.inactive2` (`#C7C7CC`) sobre `backgroundColor` (`#FFFFFF`), label do empty-state:
-  **1.68:1 — ❌ falha AA** (precisa 4.5:1). Mesmo com `muted` (opacity 0.4) reduzindo ainda mais.
+- `fonts.inactive2` (`#C7C7CC`) sobre `backgroundColor` (`#FFFFFF`), label do empty-state: **1.68:1
+  — ❌ falha AA** (precisa 4.5:1). Mesmo com `muted` (opacity 0.4) reduzindo ainda mais.
   **Pré-existente**: é o default do `FancyListEmpty` já usado sem `labelColor` nas 32 telas do app,
   não uma regressão desta sessão — meu diff só mudou layout (compact), não cor. Registrado como
-  débito, não bloqueio (texto secundário/decorativo de estado vazio, não conteúdo principal da
-  tela; corrigir aqui sem corrigir as outras 31 telas criaria inconsistência nova).
+  débito, não bloqueio (texto secundário/decorativo de estado vazio, não conteúdo principal da tela;
+  corrigir aqui sem corrigir as outras 31 telas criaria inconsistência nova).
 - `fonts.inactive2` dark (`#73737A`) sobre `#121212`: 3.98:1 — ⚠️ abaixo de 4.5 mas acima de 3:1
   (mesmo caso, pré-existente).
-- Ícone `lock-outline` do header da seção, `fonts.inactive` (`#6F6F6F`) sobre branco: 5.02:1 — ✅ AA.
+- Ícone `lock-outline` do header da seção, `fonts.inactive` (`#6F6F6F`) sobre branco: 5.02:1 — ✅
+  AA.
 
 ### Consistência interna
 
 - Zero hex hardcoded — cores via `usePallete()`/`ColorUtils.withAlpha`, inalterado.
 - `gap: 8` no compact bate com o `gap: 8` já usado no wrapper de cards da mesma tela (linha
   `{ gap: 8 }` das listas de regras/bloqueios) — mesma unidade, não valor novo.
-- `FancyButton type='text'` com ícone segue o padrão documentado no `CLAUDE.md` do frontend
-  ("Botão terciário/link → `FancyButton type='text'`").
+- `FancyButton type='text'` com ícone segue o padrão documentado no `CLAUDE.md` do frontend ("Botão
+  terciário/link → `FancyButton type='text'`").
 - `npx tsc --noEmit`: zero erros. `prettier --write` aplicado só nos 2 arquivos tocados.
 
 ### Débito de design
@@ -371,8 +377,8 @@ estados positivos/finalizados.
 - Contraste do label padrão de `FancyListEmpty` (`fonts.inactive2`, 1.68:1 light / 3.98:1 dark)
   falha AA — problema sistêmico do componente, presente nas 32 telas que o usam, não introduzido
   nesta sessão. Fix futuro: escurecer o default (ex. usar `fonts.inactive` em vez de `inactive2`
-  quando não-muted, ou aumentar contraste do tom `inactive2` em ambos os temas) — decisão de cor
-  que afeta muitas telas, precisa aprovação do usuário antes de mudar um token global.
+  quando não-muted, ou aumentar contraste do tom `inactive2` em ambos os temas) — decisão de cor que
+  afeta muitas telas, precisa aprovação do usuário antes de mudar um token global.
 - Critério 6 (riqueza gráfica) não avaliável neste escopo — correção de layout, sem expectativa de
   ilustração/gráfico novo.
 
@@ -381,41 +387,39 @@ estados positivos/finalizados.
 # Design System — Título + ícone de card de detalhe/entidade (escopo: EscalaHeader, MinisterioStatsCard)
 
 > Escopo: `EscalaHeader.tsx`, `MinisterioStatsCard.tsx` e demais cards de detalhe/entidade (card
-> único representando 1 item com dados próprios — não list item, não section header).
-> Revisão: 2026-08-05
+> único representando 1 item com dados próprios — não list item, não section header). Revisão:
+> 2026-08-05
 
 ## Regras de Design Confirmadas
 
 - **[confirmed 2026-08-05, revisado 2026-08-05]** Título de card de detalhe/entidade:
-  `FancyText type='bold' size='medium' color={palette.fonts.dark} numberOfLines={1}` em
-  qualquer variante (cheia e compacta usam o mesmo tamanho agora — `largeMedium` ficava grande
-  demais na variante cheia). Sem `lineHeight` manual — deixar o default do componente. Aplicado
-  em `EscalaHeader.tsx` e `MinisterioStatsCard.tsx` (`FullCard` e `CompactCard`).
-- **[confirmed 2026-08-05]** Subtítulo/eyebrow de seção dentro de um card (ex: "EVENTO",
-  "SETLIST", "EQUIPE" em `EscalaEventoPage.tsx`, via `renderSectionEyebrow`): ícone 12px +
+  `FancyText type='bold' size='medium' color={palette.fonts.dark} numberOfLines={1}` em qualquer
+  variante (cheia e compacta usam o mesmo tamanho agora — `largeMedium` ficava grande demais na
+  variante cheia). Sem `lineHeight` manual — deixar o default do componente. Aplicado em
+  `EscalaHeader.tsx` e `MinisterioStatsCard.tsx` (`FullCard` e `CompactCard`).
+- **[confirmed 2026-08-05]** Subtítulo/eyebrow de seção dentro de um card (ex: "EVENTO", "SETLIST",
+  "EQUIPE" em `EscalaEventoPage.tsx`, via `renderSectionEyebrow`): ícone 12px +
   `FancyText type='semiBold' size={10} color={accentLabelColor}` com label em uppercase — tier
-  hierárquico abaixo do título do card, não precisa de leading icon circular. Já era consistente
-  nas 3 ocorrências antes desta revisão; documentado aqui como padrão confirmado, sem mudança de
-  código.
+  hierárquico abaixo do título do card, não precisa de leading icon circular. Já era consistente nas
+  3 ocorrências antes desta revisão; documentado aqui como padrão confirmado, sem mudança de código.
 - **[confirmed 2026-08-05]** Ícone/avatar leading antes do título: círculo com
   `backgroundColor: ColorUtils.withAlpha(corDeReferência, 0.12)`, ícone/imagem por cima na cor
-  cheia. Quando a entidade tem imagem própria (ex: logo do ministério em
-  `MinisterioStatsCard`), usa a imagem; quando não tem (ex: escala não tem logo), usa
-  `MaterialCommunityIcons` relevante ao domínio com cor semântica já em uso no card — nunca cor
-  nova. Achado: `EscalaHeader` não tinha nenhum leading, divergindo de `MinisterioStatsCard`.
+  cheia. Quando a entidade tem imagem própria (ex: logo do ministério em `MinisterioStatsCard`), usa
+  a imagem; quando não tem (ex: escala não tem logo), usa `MaterialCommunityIcons` relevante ao
+  domínio com cor semântica já em uso no card — nunca cor nova. Achado: `EscalaHeader` não tinha
+  nenhum leading, divergindo de `MinisterioStatsCard`.
 
 ## Direção visual — Componentes (aprovada)
 
-- `EscalaHeader.tsx`: leading icon 32px circular, ícone `calendar-range`
-  (`MaterialCommunityIcons`), cor `statusVisual.color` (reaproveita a cor do status já usada na
-  borda-top do card, sem token novo), fundo `withAlpha(statusVisual.color, 0.12)`. Título sem
-  `lineHeight` manual.
+- `EscalaHeader.tsx`: leading icon 32px circular, ícone `calendar-range` (`MaterialCommunityIcons`),
+  cor `statusVisual.color` (reaproveita a cor do status já usada na borda-top do card, sem token
+  novo), fundo `withAlpha(statusVisual.color, 0.12)`. Título sem `lineHeight` manual.
 - `IgrejaCard.tsx` fica fora deste escopo — é list item (repete N vezes numa lista), não card de
   detalhe único; não herda esta regra.
 - `indisponibilidades/index.tsx`: cabeçalhos de seção "Bloqueios pessoais" e "Regras deste
-  ministério" ajustados pra `type='bold'` (eram `semiBold`), alinhando peso com o título de card
-  de detalhe. São section headers dentro de página (não card de detalhe/entidade isolado) — não
-  herdam o leading icon circular tintado; ícone `lock-outline` plano mantido como estava.
+  ministério" ajustados pra `type='bold'` (eram `semiBold`), alinhando peso com o título de card de
+  detalhe. São section headers dentro de página (não card de detalhe/entidade isolado) — não herdam
+  o leading icon circular tintado; ícone `lock-outline` plano mantido como estava.
 - `indisponibilidades/index.tsx` (revisão seguinte, mesmo dia): ícone `format-list-checks` (plano,
   16px, `palette.fonts.inactive`) adicionado no header "Regras deste ministério" pra simetria com
   `lock-outline` de "Bloqueios pessoais" — ambos section headers da mesma página, mesmo peso de
@@ -423,41 +427,42 @@ estados positivos/finalizados.
   menor que título de card de detalhe (que usa `medium`), pois são sub-seções dentro de card, não
   entidade isolada. `FancyListItemCard`/legenda do calendário (`legend`) ganhou
   `justifyContent: 'space-between'` pra alinhar item da direita na borda. `FancyListEmpty` ganhou
-  prop `containerStyle` (opcional, não quebra os outros 6 usos de `variant='compact'`) — usada
-  aqui pra centralizar o texto vazio dentro do card (`justifyContent:'center', width:'100%'`),
-  já que o `compact` padrão é alinhado à esquerda (uso original: linha inline fora de card).
+  prop `containerStyle` (opcional, não quebra os outros 6 usos de `variant='compact'`) — usada aqui
+  pra centralizar o texto vazio dentro do card (`justifyContent:'center', width:'100%'`), já que o
+  `compact` padrão é alinhado à esquerda (uso original: linha inline fora de card).
 - `indisponibilidades/index.tsx` (3ª revisão, mesmo dia, verificada por print no device): botão
   "Nova regra" trocado de `type='text'` com label (link azul solto, empurrava título pra 2 linhas)
-  pra botão circular `type='contained' mode='icon' size={38}` só com ícone `plus` — mesmo padrão
-  de `LiderancaEAcessosTab.tsx` e `RepertorioCategoriasManagerSheet.tsx` pra ação de "adicionar
-  item numa seção de card". `type='text'` sem precedente nesse contexto no app; `contained`/`light`
-  ou ícone circular são os únicos padrões usados pra essa ação. Ajuste seguinte, mesmo botão:
+  pra botão circular `type='contained' mode='icon' size={38}` só com ícone `plus` — mesmo padrão de
+  `LiderancaEAcessosTab.tsx` e `RepertorioCategoriasManagerSheet.tsx` pra ação de "adicionar item
+  numa seção de card". `type='text'` sem precedente nesse contexto no app; `contained`/`light` ou
+  ícone circular são os únicos padrões usados pra essa ação. Ajuste seguinte, mesmo botão:
   `size={38}`→`32`, ícone `22`→`24` (círculo menor, ícone relativamente maior).
 - `indisponibilidades/index.tsx` (4ª revisão, mesmo dia, verificada por print no device com dados
-  reais): `cardReadonly` (bloqueios pessoais) tinha `borderStyle:'dashed'`. Toda outra ocorrência
-  de dashed border no app (`EscalaWizardReviewStep`, `AssistenteParticipantesStep`,
-  `AssistenteRevisaoStep`) é pra estado vazio/placeholder — nunca pra item com dado real.
-  Removido `dashed`, mantido `solid` — fundo tintado (`withAlpha(fonts.inactive, 0.04)`) já
-  comunica "somente leitura" sozinho.
+  reais): `cardReadonly` (bloqueios pessoais) tinha `borderStyle:'dashed'`. Toda outra ocorrência de
+  dashed border no app (`EscalaWizardReviewStep`, `AssistenteParticipantesStep`,
+  `AssistenteRevisaoStep`) é pra estado vazio/placeholder — nunca pra item com dado real. Removido
+  `dashed`, mantido `solid` — fundo tintado (`withAlpha(fonts.inactive, 0.04)`) já comunica "somente
+  leitura" sozinho.
 - `indisponibilidades/index.tsx` (5ª revisão, mesmo dia, verificada por print no device com dados
   reais): leading icon dos itens de "Bloqueios pessoais" usava cor única `palette.fonts.inactive`
   pros 3 tipos de regra, diferente de "Regras deste ministério" que colore por tipo
-  (`LIMITE_MENSAL`→`warning`, resto→`secondary`). Perdia diferenciação visual entre itens.
-  Alinhado pra usar a mesma lógica de cor por tipo nas duas listas.
+  (`LIMITE_MENSAL`→`warning`, resto→`secondary`). Perdia diferenciação visual entre itens. Alinhado
+  pra usar a mesma lógica de cor por tipo nas duas listas.
 - `indisponibilidades/index.tsx` (6ª revisão, mesmo dia): wrapper `cardReadonly` (box cinza com
   borda em volta de cada item) removido de "Bloqueios pessoais" a pedido — itens agora são
-  `FancyListItemCard` puro (fundo branco, sem borda extra), diferenciados só pela cor do ícone
-  por tipo (decisão anterior). Style morto `cardReadonly` removido do arquivo.
+  `FancyListItemCard` puro (fundo branco, sem borda extra), diferenciados só pela cor do ícone por
+  tipo (decisão anterior). Style morto `cardReadonly` removido do arquivo.
 - `indisponibilidades/index.tsx` (7ª revisão, mesmo dia, verificada por print no device):
   `FancyListItemCard` sempre desenha card próprio (bg + borda + shadow, ver
   `FancyListItemCard.tsx:56-64`) — mesmo sem `containerStyle`, cada item de "Bloqueios pessoais"
-  ainda aparecia com card por trás. Trocado por row simples (`View` com ícone squircle 40px + texto),
-  sem card/shadow/borda — itens ficam soltos dentro do card da seção. `FancyListItemCard` mantido
-  em "Regras deste ministério" (é pressable/editável, faz sentido ter affordance de card lá).
+  ainda aparecia com card por trás. Trocado por row simples (`View` com ícone squircle 40px +
+  texto), sem card/shadow/borda — itens ficam soltos dentro do card da seção. `FancyListItemCard`
+  mantido em "Regras deste ministério" (é pressable/editável, faz sentido ter affordance de card
+  lá).
 
 - `indisponibilidades/index.tsx` (8ª revisão, mesmo dia): densidade dos itens reduzida pra caber
-  mais regras sem rolar (ação mais frequente na tela é ler/revisar, não editar — prioriza
-  densidade sobre alvo de toque generoso). 3 achados aprovados:
+  mais regras sem rolar (ação mais frequente na tela é ler/revisar, não editar — prioriza densidade
+  sobre alvo de toque generoso). 3 achados aprovados:
   1. Gap entre itens das duas listas (bloqueios pessoais e regras do ministério) era `14` — não é
      múltiplo de 4 nem 8 (grid do projeto) e era o maior contribuinte pra altura da lista. `14`→`8`.
   2. `FancyListItemCard` (regras do ministério) tem `minHeight: 78` no componente global (floor
@@ -466,44 +471,43 @@ estados positivos/finalizados.
      (`regraCardFlat`), sem tocar componente global: `minHeight: 64`.
   3. `paddingVertical` do `FancyListItemCard` é `12`/`12` (24 total) no componente global — reduzido
      localmente via mesmo `containerStyle` pra `8` (16 total), ainda múltiplo de 4/8.
-  - `regraCardFlat` final: `borderWidth:0, borderColor:'transparent', shadowOpacity:0,
-    shadowColor:'transparent', paddingHorizontal:0, paddingVertical:8, minHeight:64`.
+  - `regraCardFlat` final:
+    `borderWidth:0, borderColor:'transparent', shadowOpacity:0, shadowColor:'transparent', paddingHorizontal:0, paddingVertical:8, minHeight:64`.
 
 ## Log de telas revisadas
 
-| Tela                                        | Data       | Findings                                                                | Resultado         |
-| -------------------------------------------- | ---------- | ------------------------------------------------------------------------ | ------------------ |
-| EscalaHeader vs MinisterioStatsCard (título) | 2026-08-05 | F1 (tamanho/peso/cor já convergiam, faltava documentar), F2 (leading icon ausente em EscalaHeader), F3 (lineHeight manual divergente) | Todos aprovados e implementados |
-| Revisão de tamanho do título (largeMedium → medium) | 2026-08-05 | Título grande demais na variante cheia | Regra revisada; aplicado em EscalaHeader e MinisterioStatsCard (FullCard) |
-| indisponibilidades/index.tsx (peso dos section headers) | 2026-08-05 | semiBold divergia do bold confirmado para título de card | Ajustado pra bold; ícone leading fora de escopo (section header, não card de entidade) |
-| indisponibilidades/index.tsx (densidade de itens) | 2026-08-05 | F1 (gap 14 não é múltiplo de 4/8), F2 (minHeight 78 herdado sobrando padding), F3 (paddingVertical 12/12 do componente global) | Todos aprovados e implementados |
+| Tela                                                    | Data       | Findings                                                                                                                              | Resultado                                                                              |
+| ------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| EscalaHeader vs MinisterioStatsCard (título)            | 2026-08-05 | F1 (tamanho/peso/cor já convergiam, faltava documentar), F2 (leading icon ausente em EscalaHeader), F3 (lineHeight manual divergente) | Todos aprovados e implementados                                                        |
+| Revisão de tamanho do título (largeMedium → medium)     | 2026-08-05 | Título grande demais na variante cheia                                                                                                | Regra revisada; aplicado em EscalaHeader e MinisterioStatsCard (FullCard)              |
+| indisponibilidades/index.tsx (peso dos section headers) | 2026-08-05 | semiBold divergia do bold confirmado para título de card                                                                              | Ajustado pra bold; ícone leading fora de escopo (section header, não card de entidade) |
+| indisponibilidades/index.tsx (densidade de itens)       | 2026-08-05 | F1 (gap 14 não é múltiplo de 4/8), F2 (minHeight 78 herdado sobrando padding), F3 (paddingVertical 12/12 do componente global)        | Todos aprovados e implementados                                                        |
 
 ---
 
 # Design System — Banner de erro de submit (escopo: `FancyErrorBanner`)
 
-> Escopo: mensagem de erro em nível de submit/API dentro de modal ou formulário (ex: conflito
-> de regra ao salvar), distinta de erro de campo (validação inline).
-> Revisão: 2026-08-06
+> Escopo: mensagem de erro em nível de submit/API dentro de modal ou formulário (ex: conflito de
+> regra ao salvar), distinta de erro de campo (validação inline). Revisão: 2026-08-06
 
 ## Regra confirmada
 
 - **[confirmed 2026-08-06]** Erro de campo (validação de um input específico, ex:
-  `errors.diasSemana`) continua usando `FancyErrorText` (texto simples, sem fundo) —
-  componente tem 22 usos no app, a maioria erro de campo em `Controlled*`. Não alterado.
-- **[confirmed 2026-08-06]** Erro de nível de submit (falha ao salvar, conflito retornado pela
-  API) usa novo componente `components/forms/FancyErrorBanner.tsx`: fundo
+  `errors.diasSemana`) continua usando `FancyErrorText` (texto simples, sem fundo) — componente tem
+  22 usos no app, a maioria erro de campo em `Controlled*`. Não alterado.
+- **[confirmed 2026-08-06]** Erro de nível de submit (falha ao salvar, conflito retornado pela API)
+  usa novo componente `components/forms/FancyErrorBanner.tsx`: fundo
   `ColorUtils.withAlpha(Pallete.error, 0.12)`, borda `withAlpha(Pallete.error, 0.28)`,
   `borderRadius: 12`, ícone `alert-circle-outline` (`MaterialCommunityIcons`, 18px,
-  `Pallete.error`) + texto (`FancyErrorText`-style, `size='extraSmall' type='medium'
-  color={Pallete.error}`), row com `gap: 8`.
+  `Pallete.error`) + texto (`FancyErrorText`-style,
+  `size='extraSmall' type='medium' color={Pallete.error}`), row com `gap: 8`.
 - Motivo da separação: transformar todo `FancyErrorText` em banner colorido criaria um bloco
   vermelho pesado embaixo de cada campo de formulário do app (22 usos) — errado pro caso de uso
   (erro de campo é leve, discreto; erro de submit é evento raro que merece mais destaque).
-- Referência de padrão já existente no app: `BillingNoticeBanner.tsx` (fundo tint + ícone
-  circular + gradiente) — não reaproveitado diretamente por ser pesado demais (card com gradiente,
-  badge, CTA) pro contexto de erro inline dentro de modal; `FancyErrorBanner` é a versão
-  leve/compacta do mesmo princípio (fundo tint por tom semântico + ícone).
+- Referência de padrão já existente no app: `BillingNoticeBanner.tsx` (fundo tint + ícone circular +
+  gradiente) — não reaproveitado diretamente por ser pesado demais (card com gradiente, badge, CTA)
+  pro contexto de erro inline dentro de modal; `FancyErrorBanner` é a versão leve/compacta do mesmo
+  princípio (fundo tint por tom semântico + ícone).
 
 ## Onde usar
 
@@ -522,8 +526,8 @@ estados positivos/finalizados.
 # Design System — EventoFormModal (escopo: assistente de escalas, bottom sheet "Editar Evento")
 
 > Escopo: `EventoFormModal.tsx` + dependências diretas (`FancyBottomSheetModal`,
-> `FancyContainerList`, `FancyCard.Simple`/`FancyBaseCard`, `EscalaFormFuncaoList`).
-> Revisão: 2026-08-15
+> `FancyContainerList`, `FancyCard.Simple`/`FancyBaseCard`, `EscalaFormFuncaoList`). Revisão:
+> 2026-08-15
 
 ## Regras de Design Confirmadas
 
@@ -533,15 +537,15 @@ estados positivos/finalizados.
   seção (`FancyContainerList`, `size='medium' type='bold'`) e título de cada item de lista
   (`FancyBaseCard`, `size='medium' type='bold'`) renderizam no mesmo tamanho/peso (13px bold via
   `MEDIUM_SIZE_FONT`) — três níveis de hierarquia colapsam num só, sem diferenciação visual.
-- Regra: título de sheet sobe pra `size='largeMedium'` (15px), mantendo `type='bold'` —
-  diferencia do header de seção e do item de lista, que continuam em `medium` (13px). Sheet title
-  é o nível mais alto da tela (nome do evento), não deveria competir visualmente com sub-elementos.
+- Regra: título de sheet sobe pra `size='largeMedium'` (15px), mantendo `type='bold'` — diferencia
+  do header de seção e do item de lista, que continuam em `medium` (13px). Sheet title é o nível
+  mais alto da tela (nome do evento), não deveria competir visualmente com sub-elementos.
 
 ### Cores — ações de header de lista (add vs. destrutiva)
 
-- **[confirmed 2026-08-15]** Achado: botões `+` (adicionar) e limpar-tudo
-  (`list-clear`) no header de `FancyContainerList` renderizam ambos com `type='contained'`,
-  mesma cor azul (`palette.buttons.active`) — nenhuma distinção visual entre ação aditiva e ação
+- **[confirmed 2026-08-15]** Achado: botões `+` (adicionar) e limpar-tudo (`list-clear`) no header
+  de `FancyContainerList` renderizam ambos com `type='contained'`, mesma cor azul
+  (`palette.buttons.active`) — nenhuma distinção visual entre ação aditiva e ação
   destrutiva/irreversível (limpar toda a lista de equipe).
 - Regra (reforça `CLAUDE.md` do frontend: "Ações destrutivas → `palette.error` sólido com
   `palette.icons.light`"): botão de limpar-tudo em `FancyContainerList.buttons` usa
@@ -554,13 +558,12 @@ estados positivos/finalizados.
 - **[confirmed 2026-08-15]** Achado: `FancyBaseCard` (usado por `FancyCard.Simple` na seção
   "Equipe") renderiza ~70px por item, 3 linhas empilhadas (título/subtítulo/dado adicional) —
   confirmado que a lista "Equipe" tipicamente tem 6-15 itens, então o card atual força rolagem
-  pesada pro caso comum.
-  o card atual força rolagem pesada pro caso comum.
-- Regra: listas com contagem tipicamente ≥6 itens usam variante compacta de item (título +
-  subtítulo numa linha só, ícone de ação menor) — mesmo princípio já aplicado em
+  pesada pro caso comum. o card atual força rolagem pesada pro caso comum.
+- Regra: listas com contagem tipicamente ≥6 itens usam variante compacta de item (título + subtítulo
+  numa linha só, ícone de ação menor) — mesmo princípio já aplicado em
   `indisponibilidades/index.tsx` (ver seção acima, "densidade de itens": `paddingVertical` 12→8,
-  remoção de padding morto). Aplicar override local via `containerStyle` no `FancyCard.Simple`
-  desta tela, sem mudar o default global de `FancyBaseCard` (79+ outros usos no app).
+  remoção de padding morto). Aplicar override local via `containerStyle` no `FancyCard.Simple` desta
+  tela, sem mudar o default global de `FancyBaseCard` (79+ outros usos no app).
 
 ### Rótulo obrigatório em campo de dado
 
@@ -573,35 +576,35 @@ estados positivos/finalizados.
 
 ## Log de Telas Revisadas
 
-| Tela                                    | Data       | Findings                                                                                                        | Resultado                        |
-| ---------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| Tela                                    | Data       | Findings                                                                                                                           | Resultado                                |
+| --------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | EventoFormModal (assistente de escalas) | 2026-08-15 | F1 (hierarquia sheet/seção/item colapsada), F2 (add/limpar-tudo mesma cor), F3 (densidade item p/ lista 6-15), F4 (data sem label) | Todos aprovados — implementação pendente |
 
 ---
 
 # Design System — NotificationButton + FancyHeader (escopo: botão de notificações e header padrão)
 
-> Escopo: `components/header/NotificationButton.tsx`, `components/header/FancyHeader.tsx`.
-> Revisão: 2026-08-17
+> Escopo: `components/header/NotificationButton.tsx`, `components/header/FancyHeader.tsx`. Revisão:
+> 2026-08-17
 
 ## Regras Confirmadas
 
 - **[confirmed 2026-08-17]** Badge do sino de notificações é indicador binário (tem/não tem
-  não-lida), não contador — usa dot fixo `8×8px`, sem número dentro. Motivo: número de 2-3
-  dígitos não cabia sem distorcer o círculo em nenhum tamanho testado; usuário preferiu o padrão
-  dot (iOS/Gmail/WhatsApp) a ajustar o círculo pro número. Ver histórico abaixo — havia uma
-  primeira correção (diâmetro/fonte fixos, 19px/11px) que ficou obsoleta por esta.
-- **[confirmed 2026-08-17]** Posição do dot (`right: -2, top: 0` sobre ícone de 19px) — avaliado
-  e aprovado, não encosta na silhueta do sino no build atual.
+  não-lida), não contador — usa dot fixo `8×8px`, sem número dentro. Motivo: número de 2-3 dígitos
+  não cabia sem distorcer o círculo em nenhum tamanho testado; usuário preferiu o padrão dot
+  (iOS/Gmail/WhatsApp) a ajustar o círculo pro número. Ver histórico abaixo — havia uma primeira
+  correção (diâmetro/fonte fixos, 19px/11px) que ficou obsoleta por esta.
+- **[confirmed 2026-08-17]** Posição do dot (`right: -2, top: 0` sobre ícone de 19px) — avaliado e
+  aprovado, não encosta na silhueta do sino no build atual.
 
 ## Achados avaliados (sem ação)
 
-- Touch target do container do sino (`24×30`) abaixo do mínimo `≥44px` do checklist do
-  `CLAUDE.md` do frontend — **débito registrado, não corrigido nesta rodada** (fora do escopo
-  pedido pelo usuário).
-- Alinhamento vertical entre `HeaderMenuButton` (ícone+título) — mecanismo é
-  `flexDirection:'row'` + `alignItems:'center'`, estruturalmente correto; qualquer desvio visual
-  fica a nível de métrica de fonte (Montserrat), não bug de layout. Sem ação.
+- Touch target do container do sino (`24×30`) abaixo do mínimo `≥44px` do checklist do `CLAUDE.md`
+  do frontend — **débito registrado, não corrigido nesta rodada** (fora do escopo pedido pelo
+  usuário).
+- Alinhamento vertical entre `HeaderMenuButton` (ícone+título) — mecanismo é `flexDirection:'row'` +
+  `alignItems:'center'`, estruturalmente correto; qualquer desvio visual fica a nível de métrica de
+  fonte (Montserrat), não bug de layout. Sem ação.
 - Tamanho do título do header (`largeMedium`/`medium`) vs. `DashboardSection` eyebrow
   (`size='small'`) — proporção 15:12 é degrau de escala normal, hierarquia correta. Sem ação.
 
@@ -613,9 +616,9 @@ estados positivos/finalizados.
 
 ## Log de Telas Revisadas
 
-| Tela | Data | Findings | Resultado |
-| --- | --- | --- | --- |
-| NotificationButton (badge) | 2026-08-17 | Número "13" estourava círculo em qualquer tamanho fixo testado | Trocado por dot 8px sem número |
+| Tela                                               | Data       | Findings                                                                                                                           | Resultado                                                    |
+| -------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| NotificationButton (badge)                         | 2026-08-17 | Número "13" estourava círculo em qualquer tamanho fixo testado                                                                     | Trocado por dot 8px sem número                               |
 | NotificationButton + FancyHeader (avaliação livre) | 2026-08-17 | F1 (touch target <44px), F2 (posição do dot — rejeitado, não se aplica), F3 (alinhamento título — ok), F4 (tamanho do título — ok) | F1 registrado como débito; F2 rejeitado (R1); F3/F4 sem ação |
 
 ---
@@ -627,47 +630,44 @@ estados positivos/finalizados.
 
 ## Entendimento (advise + grilling, fechado com o usuário)
 
-- Banner aparece na listagem de escalas do ministério, **só quando o checklist está incompleto**
-  — pensado pro primeiro acesso (líder novo que já quer sair gerando escala sem ter configurado
-  nada). Também um item de menu na mesma tela, acessível a qualquer momento.
-- Admin usa a mesma visão do líder, ministério por ministério — sem tela agregada por igreja
-  nesta fase (`GET /igrejas/:id/checklist-escala` fica sem consumo no app por ora).
-- Pré-checagem intercepta automaticamente o botão "Gerar" no último passo do Assistente já
-  existente (`assistant.tsx`) — nunca bloqueia (ADR 0003), só avisa com opção "Gerar mesmo
-  assim".
+- Banner aparece na listagem de escalas do ministério, **só quando o checklist está incompleto** —
+  pensado pro primeiro acesso (líder novo que já quer sair gerando escala sem ter configurado nada).
+  Também um item de menu na mesma tela, acessível a qualquer momento.
+- Admin usa a mesma visão do líder, ministério por ministério — sem tela agregada por igreja nesta
+  fase (`GET /igrejas/:id/checklist-escala` fica sem consumo no app por ora).
+- Pré-checagem intercepta automaticamente o botão "Gerar" no último passo do Assistente já existente
+  (`assistant.tsx`) — nunca bloqueia (ADR 0003), só avisa com opção "Gerar mesmo assim".
 - Tela de uso raro (configuração, não daily driver).
 
 ## Conceito
 
 - **Paradigma**: nenhum dos 12 paradigmas-padrão isolado — é essencialmente uma variação de
-  "Master-detail com preview inline" (item 7), mas com o preview substituindo o resultado
-  esperado ("check") por um **resultado real** (contagem) quando resolvido. Casa com a dimensão
-  dominante (estado de configuração, não dado temporal/espacial/conversa) e a restrição mobile
-  (baixa densidade, uma ação óbvia por vez, thumb zone).
+  "Master-detail com preview inline" (item 7), mas com o preview substituindo o resultado esperado
+  ("check") por um **resultado real** (contagem) quando resolvido. Casa com a dimensão dominante
+  (estado de configuração, não dado temporal/espacial/conversa) e a restrição mobile (baixa
+  densidade, uma ação óbvia por vez, thumb zone).
 - **Estrutura OOUX**:
-  - `Passo do Checklist` (função/vínculo/função-do-voluntário) → não vira tela própria, nem
-    lista genérica com checkbox — vira **linha de estado** dentro de um card expansível na
-    listagem de escalas (ver Direção abaixo).
+  - `Passo do Checklist` (função/vínculo/função-do-voluntário) → não vira tela própria, nem lista
+    genérica com checkbox — vira **linha de estado** dentro de um card expansível na listagem de
+    escalas (ver Direção abaixo).
   - `Checklist` (agregador dos 3 passos, por ministério) → não é tela própria nesta fase — é o
     card/banner citado acima, aberto por toque ou pelo item de menu.
   - `Pré-checagem` (por vaga/evento) → modal (`FancyModalDialog`), intercepta o botão "Gerar".
   - `Função` (cadastro) → sem tela nova; reaproveita o cadastro de função já existente
-    (`ministerio-funcoes`), só ganha sugestões (catálogo) — decisão de onde vive o catálogo
-    ainda em aberto, não bloqueia o conceito de tela.
-- **Elemento-assinatura**: **"a frase que muda de sentença"** — no topo do card, uma única linha
-  de status narra o que falta em linguagem de domínio ("Falta cadastrar função" → "Falta
-  vincular voluntários" → "Falta atribuir função aos voluntários" → "Ministério pronto pra
-  escalar"), recalculada ao vivo conforme o líder resolve cada passo. Nunca frasa como
-  bloqueio/impedimento (ADR 0003: avisa, não bloqueia) — sempre framing de "falta X", nunca "não
-  pode Y".
-  - Item resolvido **não vira checkmark** — vira um chip com o dado real que foi criado (ex:
-    "4 funções", "9 voluntários"), reforçando "você construiu algo" em vez de "você marcou uma
-    tarefa".
+    (`ministerio-funcoes`), só ganha sugestões (catálogo) — decisão de onde vive o catálogo ainda em
+    aberto, não bloqueia o conceito de tela.
+- **Elemento-assinatura**: **"a frase que muda de sentença"** — no topo do card, uma única linha de
+  status narra o que falta em linguagem de domínio ("Falta cadastrar função" → "Falta vincular
+  voluntários" → "Falta atribuir função aos voluntários" → "Ministério pronto pra escalar"),
+  recalculada ao vivo conforme o líder resolve cada passo. Nunca frasa como bloqueio/impedimento
+  (ADR 0003: avisa, não bloqueia) — sempre framing de "falta X", nunca "não pode Y".
+  - Item resolvido **não vira checkmark** — vira um chip com o dado real que foi criado (ex: "4
+    funções", "9 voluntários"), reforçando "você construiu algo" em vez de "você marcou uma tarefa".
   - Item ainda não alcançável na ordem lógica (ex: atribuir função sem ter voluntário vinculado
-    ainda) fica visualmente esmaecido, mas **continua tocável** — nunca trava navegação
-    (consistente com "nunca bloqueia").
-  - Cada linha é tocável por inteiro (sem `FancyButton` dentro da linha) — toque no corpo da
-    linha navega pro cadastro correspondente.
+    ainda) fica visualmente esmaecido, mas **continua tocável** — nunca trava navegação (consistente
+    com "nunca bloqueia").
+  - Cada linha é tocável por inteiro (sem `FancyButton` dentro da linha) — toque no corpo da linha
+    navega pro cadastro correspondente.
 - **Gate da Lei de Jakob**: passou. Trocando cor/logo por um concorrente do mesmo segmento, a
   estrutura ainda seria reconhecível — nenhum outro app de escala voluntária usa "frase de status
   que narra o próximo passo em linguagem de domínio" + "chip de contagem real em vez de check" no
@@ -675,114 +675,115 @@ estados positivos/finalizados.
 
 ### Direções descartadas (subagentes paralelos, técnicas de divergência)
 
-| Direção | Técnica | Por que descartada (parcial) |
-| --- | --- | --- |
-| "GO/NO-GO de palco" (veredito bloqueante, itens com severidade) | Analogia forçada (backstage de show) | Framing "escala não pode ser gerada" contradiz ADR 0003 (nunca bloqueia) — mantida só a ideia de frase de status dinâmica, reescrita sem linguagem de bloqueio |
-| Cadeado que trava item 3 até 1+2 resolverem | Estratégia oblíqua (sem botão) | Lock literal implica bloqueio de navegação, que o produto não tem hoje — mantida só a ideia de linha inteira tocável (sem botão) e esmaecimento visual sem travar toque |
-| Trilha horizontal fixa de 3 estações | SCAMPER Eliminate | Estrutura de trilha não cabia bem no espaço de uma listagem de escalas (empurraria conteúdo real da tela) — mantida a ideia central (chip com contagem real em vez de check) |
+| Direção                                                         | Técnica                              | Por que descartada (parcial)                                                                                                                                                 |
+| --------------------------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "GO/NO-GO de palco" (veredito bloqueante, itens com severidade) | Analogia forçada (backstage de show) | Framing "escala não pode ser gerada" contradiz ADR 0003 (nunca bloqueia) — mantida só a ideia de frase de status dinâmica, reescrita sem linguagem de bloqueio               |
+| Cadeado que trava item 3 até 1+2 resolverem                     | Estratégia oblíqua (sem botão)       | Lock literal implica bloqueio de navegação, que o produto não tem hoje — mantida só a ideia de linha inteira tocável (sem botão) e esmaecimento visual sem travar toque      |
+| Trilha horizontal fixa de 3 estações                            | SCAMPER Eliminate                    | Estrutura de trilha não cabia bem no espaço de uma listagem de escalas (empurraria conteúdo real da tela) — mantida a ideia central (chip com contagem real em vez de check) |
 
 ### Revisão 2026-08-21 — Checklist vira tela própria
 
 Durante a camada de cor (`trfernandes-atelier-explore` Ramo A), o usuário revisou um ponto do
 entendimento acima: o card/banner na listagem de escalas **continua existindo** como ponto de
-entrada (sugestão no primeiro acesso + item de menu), mas agora é só um **teaser compacto**
-(frase de status + indicador de toque) — ele não expande mais os 3 passos in-place. Tocar no
-teaser (ou no item de menu) **navega pra uma tela própria do Checklist**, que mostra os mesmos 3
-passos (mesmo conteúdo, mesmo elemento-assinatura "frase que muda de sentença" + chip com dado
-real), só que em tela cheia. Essa tela não tem entrada própria fora desses dois pontos — não vira
-destino de menu lateral nem tab, é alcançável só a partir da listagem de escalas do ministério.
+entrada (sugestão no primeiro acesso + item de menu), mas agora é só um **teaser compacto** (frase
+de status + indicador de toque) — ele não expande mais os 3 passos in-place. Tocar no teaser (ou no
+item de menu) **navega pra uma tela própria do Checklist**, que mostra os mesmos 3 passos (mesmo
+conteúdo, mesmo elemento-assinatura "frase que muda de sentença" + chip com dado real), só que em
+tela cheia. Essa tela não tem entrada própria fora desses dois pontos — não vira destino de menu
+lateral nem tab, é alcançável só a partir da listagem de escalas do ministério.
 
 Cogitou-se também mostrar um card equivalente em Início (dashboard) — descartado pelo usuário
 ("esqueci desse detalhe, esquece essa ideia"), fora de escopo desta fase.
 
 Isso muda a estrutura OOUX (linha 647-656 acima):
-- `Passo do Checklist` → continua **linha de estado**, mas agora dentro da tela própria, não do
-  card da listagem.
-- `Checklist` (agregador dos 3 passos) → **é tela própria** nesta fase (correção do texto
-  original acima, que dizia o contrário) — reaproveita a mesma linguagem visual e cores já
-  aprovadas (Variante F, ver seção Cor abaixo).
-- O card da listagem passa a ser só o `Teaser do Checklist` — objeto novo, compacto: mesma frase
-  de status como título, sem os 3 passos, com indicador de navegação (chevron).
 
-Paradigma ajustado: deixa de ser puramente "Master-detail com preview inline" (item 7) e passa a
-ser um híbrido com "Lista + detalhe" (item 1) — o teaser na listagem funciona como o item de
-lista compacto, a tela própria é o detalhe pra onde a navegação leva. O elemento-assinatura (frase
-que muda de sentença, chip com dado real, esmaecido mas tocável) continua idêntico — só migrou de
+- `Passo do Checklist` → continua **linha de estado**, mas agora dentro da tela própria, não do card
+  da listagem.
+- `Checklist` (agregador dos 3 passos) → **é tela própria** nesta fase (correção do texto original
+  acima, que dizia o contrário) — reaproveita a mesma linguagem visual e cores já aprovadas
+  (Variante F, ver seção Cor abaixo).
+- O card da listagem passa a ser só o `Teaser do Checklist` — objeto novo, compacto: mesma frase de
+  status como título, sem os 3 passos, com indicador de navegação (chevron).
+
+Paradigma ajustado: deixa de ser puramente "Master-detail com preview inline" (item 7) e passa a ser
+um híbrido com "Lista + detalhe" (item 1) — o teaser na listagem funciona como o item de lista
+compacto, a tela própria é o detalhe pra onde a navegação leva. O elemento-assinatura (frase que
+muda de sentença, chip com dado real, esmaecido mas tocável) continua idêntico — só migrou de
 container (card expansível → tela).
 
 ## Direção visual (trfernandes-atelier-explore Ramo A — aprovado 2026-08-21)
 
 ### Cor — Variante F ("cada passo com sua cor")
 
-Cada passo do checklist recebe uma cor de "competência" própria, emprestada do sistema de cores
-de seção do repertório (`utils/secaoCores.ts`) — nenhuma dessas cores passa por `usePallete()`,
-foi um achado explícito pedido pelo usuário depois de reprovar as 3 primeiras variantes (cinza
-demais, verde feio). Ao resolver, cada passo converge pra esmeralda (`statusThemes.ts`,
-tema `APPROVED`/`ATIVO`), também fora do `usePallete()`.
+Cada passo do checklist recebe uma cor de "competência" própria, emprestada do sistema de cores de
+seção do repertório (`utils/secaoCores.ts`) — nenhuma dessas cores passa por `usePallete()`, foi um
+achado explícito pedido pelo usuário depois de reprovar as 3 primeiras variantes (cinza demais,
+verde feio). Ao resolver, cada passo converge pra esmeralda (`statusThemes.ts`, tema
+`APPROVED`/`ATIVO`), também fora do `usePallete()`.
 
-| Papel | Claro | Escuro | Origem |
-| --- | --- | --- | --- |
-| Passo "Funções cadastradas" | `#0EA5A5` | `#2DD4D4` | `secaoCores.ts` (seção Instrumental) |
-| Passo "Voluntários vinculados" | `#6D5EF3` | `#8C7EF7` | `secaoCores.ts` (seção Ponte) |
-| Passo "Função atribuída" | `#E67E22` | `#F0954A` | `secaoCores.ts` (seção Solo) |
-| Resolvido / conquista | borda `#059669` · destaque `#10B981` | borda `#10B981` · destaque `#34D399` | `statusThemes.ts` (APPROVED/ATIVO) |
-| CTA ("Continuar configuração") | `palette.primary` (`#3B82F6`) | idem | `usePallete()` — **não muda por feature**, regra já documentada acima |
-| Texto/legenda/esmaecido | `palette.fonts.dark` / `.inactive` / `.inactive2` | idem | `usePallete()` |
+| Papel                          | Claro                                             | Escuro                               | Origem                                                                |
+| ------------------------------ | ------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------------- |
+| Passo "Funções cadastradas"    | `#0EA5A5`                                         | `#2DD4D4`                            | `secaoCores.ts` (seção Instrumental)                                  |
+| Passo "Voluntários vinculados" | `#6D5EF3`                                         | `#8C7EF7`                            | `secaoCores.ts` (seção Ponte)                                         |
+| Passo "Função atribuída"       | `#E67E22`                                         | `#F0954A`                            | `secaoCores.ts` (seção Solo)                                          |
+| Resolvido / conquista          | borda `#059669` · destaque `#10B981`              | borda `#10B981` · destaque `#34D399` | `statusThemes.ts` (APPROVED/ATIVO)                                    |
+| CTA ("Continuar configuração") | `palette.primary` (`#3B82F6`)                     | idem                                 | `usePallete()` — **não muda por feature**, regra já documentada acima |
+| Texto/legenda/esmaecido        | `palette.fonts.dark` / `.inactive` / `.inactive2` | idem                                 | `usePallete()`                                                        |
 
-Correção registrada durante a camada de componentes: o CTA tinha sido desenhado em teal por
-engano — corrigido pra `palette.primary` porque a regra "botão principal = CTA sólido" não varia
-por feature (só ícone/chip/indicador tem liberdade de cor própria).
+Correção registrada durante a camada de componentes: o CTA tinha sido desenhado em teal por engano —
+corrigido pra `palette.primary` porque a regra "botão principal = CTA sólido" não varia por feature
+(só ícone/chip/indicador tem liberdade de cor própria).
 
 ### Tipografia — "Hero de impacto"
 
 Nenhuma fonte nova (app inteiro usa Montserrat). Escala de 3 níveis, toda reaproveitada de
 `constants/font.ts` / `FancyText`:
 
-| Elemento | Token | px | Peso |
-| --- | --- | --- | --- |
-| Frase de status (elemento-assinatura, hero da tela própria) | `size='titleLarge'` | 22 | bold |
-| Título do passo | `size='mediumLarge'` | 14 | semiBold |
-| Legenda do passo / subtítulo do hero | `size='extraSmall'`/`'small'` | 11-12 | medium |
-| Título do teaser (card na listagem) | `size='small'` | 12 | bold |
-| Chip resolvido | preset `medium` de `FancyChips` | ~12 | bold |
+| Elemento                                                    | Token                           | px    | Peso     |
+| ----------------------------------------------------------- | ------------------------------- | ----- | -------- |
+| Frase de status (elemento-assinatura, hero da tela própria) | `size='titleLarge'`             | 22    | bold     |
+| Título do passo                                             | `size='mediumLarge'`            | 14    | semiBold |
+| Legenda do passo / subtítulo do hero                        | `size='extraSmall'`/`'small'`   | 11-12 | medium   |
+| Título do teaser (card na listagem)                         | `size='small'`                  | 12    | bold     |
+| Chip resolvido                                              | preset `medium` de `FancyChips` | ~12   | bold     |
 
 `titleLarge` não tinha uso em produção antes desta tela — precedente parcial em `DashboardCard`
-(`size='title'`, 20px, pra número de destaque); aqui sobe um nível porque a frase É o motivo da
-tela existir, não um dado secundário dentro de um card.
+(`size='title'`, 20px, pra número de destaque); aqui sobe um nível porque a frase É o motivo da tela
+existir, não um dado secundário dentro de um card.
 
 ### Componentes
 
 - **Teaser do Checklist** (novo, na listagem de escalas): reaproveita a linguagem visual de
   `FancyListItemCard` (raio 18, `shadows[200]`, borda 0.5 @ 45% alpha) — ícone 34px + frase de
-  status (12px bold) + legenda (11px) + chevron. Sem os 3 passos aqui; toque navega pra tela
-  própria do Checklist.
+  status (12px bold) + legenda (11px) + chevron. Sem os 3 passos aqui; toque navega pra tela própria
+  do Checklist.
 - **Step Row** (elemento-assinatura sistematizado, dentro da tela própria do Checklist): ícone
-  24-38px na cor do passo (16% alpha, 10% quando esmaecido, esmeralda quando resolvido) + label
-  14px semiBold + legenda 11px + chip esmeralda com dado real (resolvido) ou seta `›` (não
-  resolvido, sempre tocável mesmo esmaecido). Linha inteira tocável, sem `FancyButton` dentro.
+  24-38px na cor do passo (16% alpha, 10% quando esmaecido, esmeralda quando resolvido) + label 14px
+  semiBold + legenda 11px + chip esmeralda com dado real (resolvido) ou seta `›` (não resolvido,
+  sempre tocável mesmo esmaecido). Linha inteira tocável, sem `FancyButton` dentro.
 - **Modal de pré-checagem**: `FancyBottomSheetModal` — **revisão da decisão original do conceito**
-  (que previa `FancyModalDialog`, diálogo centralizado). Apareceu como bottom sheet por engano
-  num mockup da camada de cor; o usuário revisou e preferiu manter bottom sheet depois de ver as
-  duas opções lado a lado na camada de componentes. Botões empilhados (não lado a lado): "Gerar
-  mesmo assim" (contained, `primary`) em cima, "Revisar checklist" (outlined) embaixo — segue a
-  hierarquia já documentada (1 contained por contexto).
+  (que previa `FancyModalDialog`, diálogo centralizado). Apareceu como bottom sheet por engano num
+  mockup da camada de cor; o usuário revisou e preferiu manter bottom sheet depois de ver as duas
+  opções lado a lado na camada de componentes. Botões empilhados (não lado a lado): "Gerar mesmo
+  assim" (contained, `primary`) em cima, "Revisar checklist" (outlined) embaixo — segue a hierarquia
+  já documentada (1 contained por contexto).
 
 ### Motivo gráfico — "Selo de Etapa"
 
 Cada competência de configuração (função / vínculo / atribuição) ganha um selo colorido próprio
-(ícone dentro de um quadrado arredondado com fundo tintado) que muda de cor pra esmeralda só
-quando a etapa é conquistada — não é decoração, é o mecanismo central de leitura do checklist.
-Aplicado em 3 lugares estruturalmente diferentes: (1) ícone do teaser compacto na listagem, (2)
-ícone de cada `Step Row` na tela própria, (3) cor do chip de dado real quando resolvido. Deriva
-do sistema de cores por seção que já existe no repertório musical do app (`secaoCores.ts`) —
-mesma lógica de "cada categoria tem sua identidade visual", aplicada agora a etapas de
-configuração em vez de seções de música.
+(ícone dentro de um quadrado arredondado com fundo tintado) que muda de cor pra esmeralda só quando
+a etapa é conquistada — não é decoração, é o mecanismo central de leitura do checklist. Aplicado em
+3 lugares estruturalmente diferentes: (1) ícone do teaser compacto na listagem, (2) ícone de cada
+`Step Row` na tela própria, (3) cor do chip de dado real quando resolvido. Deriva do sistema de
+cores por seção que já existe no repertório musical do app (`secaoCores.ts`) — mesma lógica de "cada
+categoria tem sua identidade visual", aplicada agora a etapas de configuração em vez de seções de
+música.
 
 ### Estrutura de telas (revisão 2026-08-21, ver acima)
 
-Teaser compacto na listagem de escalas → navega pra tela própria "Checklist" (não expande
-in-place) → tela mostra os 3 `Step Row` completos → modal `FancyBottomSheetModal` intercepta o
-botão "Gerar" do Assistente (`assistant.tsx`), nunca bloqueia (ADR 0003).
+Teaser compacto na listagem de escalas → navega pra tela própria "Checklist" (não expande in-place)
+→ tela mostra os 3 `Step Row` completos → modal `FancyBottomSheetModal` intercepta o botão "Gerar"
+do Assistente (`assistant.tsx`), nunca bloqueia (ADR 0003).
 
 ## Próximo passo
 


### PR DESCRIPTION
Só docs (design-system.md): direção visual do Checklist, conceito e direção visual de Saúde do Voluntariado, slide de quiz de vendas. Recuperado após fechar PR #15 (cujo conteúdo original de código já estava em master por outro caminho — este era só o commit de docs sobrevivente no HEAD atual da branch). Aberta pra preservar — merge fica pra quando a versão for organizada.